### PR TITLE
fix(security): prevent XSS in frontend innerHTML interpolations

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -74,10 +74,12 @@
 
 ## CEO Review (2026-03-18) — Pre-open-source
 
-### TODO-13: escapeHtml() for all innerHTML calls (XSS prevention)
-- All JS modules use `.innerHTML` without escaping — stored XSS vector
-- Risk is low for internal lab (data from OCR, not web input), but blocks open-source
-- Add `escapeHtml()` utility and apply to all innerHTML assignments in static/js/*.js
+### TODO-13: escapeHtml() for all innerHTML calls (XSS prevention) ✅ (fix/xss-innerhtml)
+- escapeHtml() exists in api.js and is applied to all API string values before innerHTML
+- Fixed bug: `if (!s)` → `if (s == null || s === "")` so numeric 0 is handled correctly
+- dashboard.js: added escapeHtml() to all card/alert template interpolations
+- orders.js / inventory.js: parseInt() for page numbers from API responses
+- Added 2 API-level XSS tests in test_api_security.py (vendor/product names with HTML chars)
 - Priority: P2 | Effort: S | Depends on: nothing
 
 ### TODO-14: Duplicate order detection (PO# matching)

--- a/src/lab_manager/static/js/api.js
+++ b/src/lab_manager/static/js/api.js
@@ -20,10 +20,12 @@ async function apiFetch(url, opts) {
 }
 
 /**
- * XSS prevention — escape HTML entities.
+ * XSS prevention — escape HTML entities before inserting into innerHTML.
+ * Must be called on every API-supplied string value before interpolation.
+ * Returns "" for null/undefined; handles numeric 0 correctly.
  */
 function escapeHtml(s) {
-  if (!s) return "";
+  if (s == null || s === "") return "";
   return String(s)
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")

--- a/src/lab_manager/static/js/dashboard.js
+++ b/src/lab_manager/static/js/dashboard.js
@@ -50,7 +50,7 @@ function renderStats() {
       icon: "shopping_cart",
       label: "Orders",
       value: s.total_orders,
-      sub: s.total_items + " line items",
+      sub: parseInt(s.total_items, 10) + " line items",
       color: "text-primary",
     },
     {
@@ -67,11 +67,11 @@ function renderStats() {
       (c) => `
     <div class="bg-surface-dark border border-border-dark rounded-xl p-5">
       <div class="flex items-center gap-3 mb-2">
-        <span class="material-symbols-outlined text-slate-500 text-xl">${c.icon}</span>
-        <span class="text-xs text-slate-500 uppercase tracking-wider font-medium">${c.label}</span>
+        <span class="material-symbols-outlined text-slate-500 text-xl">${escapeHtml(c.icon)}</span>
+        <span class="text-xs text-slate-500 uppercase tracking-wider font-medium">${escapeHtml(c.label)}</span>
       </div>
-      <div class="text-3xl font-bold ${c.color}">${c.value}</div>
-      <div class="text-xs text-slate-500 mt-1">${c.sub}</div>
+      <div class="text-3xl font-bold ${escapeHtml(c.color)}">${escapeHtml(String(c.value))}</div>
+      <div class="text-xs text-slate-500 mt-1">${escapeHtml(c.sub)}</div>
     </div>`
     )
     .join("");
@@ -89,9 +89,9 @@ function renderStats() {
   alertContainer.innerHTML = alerts
     .map(
       (a) => `
-    <div class="flex items-center gap-3 p-3 rounded-lg border ${a.cls}">
-      <span class="material-symbols-outlined text-amber-400">${a.icon}</span>
-      <span class="text-sm text-slate-300">${a.text}</span>
+    <div class="flex items-center gap-3 p-3 rounded-lg border ${escapeHtml(a.cls)}">
+      <span class="material-symbols-outlined text-amber-400">${escapeHtml(a.icon)}</span>
+      <span class="text-sm text-slate-300">${escapeHtml(a.text)}</span>
     </div>`
     )
     .join("");
@@ -116,7 +116,7 @@ function renderVendorChart(s) {
     <div class="flex items-center gap-3 mb-2 text-sm">
       <div class="w-36 text-right text-slate-400 truncate" title="${escapeHtml(v.name || "")}">${escapeHtml(v.name || "")}</div>
       <div class="h-5 bg-primary rounded" style="width: ${(v.count / maxCount) * 200}px; min-width: 4px;"></div>
-      <div class="text-slate-300 font-semibold w-8">${v.count}</div>
+      <div class="text-slate-300 font-semibold w-8">${parseInt(v.count, 10)}</div>
     </div>`
     )
     .join("");
@@ -139,7 +139,7 @@ function renderTypeChart(s) {
     <div class="flex items-center gap-3 mb-2 text-sm">
       <div class="w-36 text-right text-slate-400 truncate">${escapeHtml(name || "")}</div>
       <div class="h-5 bg-accent-green rounded" style="width: ${(count / maxType) * 200}px; min-width: 4px;"></div>
-      <div class="text-slate-300 font-semibold w-8">${count}</div>
+      <div class="text-slate-300 font-semibold w-8">${parseInt(count, 10)}</div>
     </div>`
     )
     .join("");

--- a/src/lab_manager/static/js/inventory.js
+++ b/src/lab_manager/static/js/inventory.js
@@ -20,7 +20,7 @@ async function loadInventory() {
     renderInvRows(items);
     document.getElementById("inv-total").textContent =
       data.total != null ? data.total + " items" : "";
-    renderInvPagination(data.page || 1, data.pages || 1);
+    renderInvPagination(parseInt(data.page, 10) || 1, parseInt(data.pages, 10) || 1);
   } catch (err) {
     if (err.message !== "Unauthorized") {
       console.error("Failed to load inventory:", err);

--- a/src/lab_manager/static/js/orders.js
+++ b/src/lab_manager/static/js/orders.js
@@ -78,8 +78,8 @@ function formatCurrency(amount) {
 function renderOrdPagination(data) {
   const el = document.getElementById("ord-pagination");
   if (!el) return;
-  const page = data.page || 1;
-  const pages = data.pages || 1;
+  const page = parseInt(data.page, 10) || 1;
+  const pages = parseInt(data.pages, 10) || 1;
   el.innerHTML = `
     <button onclick="ordChangePage(-1)" ${page <= 1 ? "disabled" : ""}
       class="px-3 py-1.5 rounded-lg border border-border-dark text-slate-400 hover:text-white hover:border-primary disabled:opacity-30 disabled:cursor-not-allowed transition-colors text-sm">

--- a/tests/test_api_security.py
+++ b/tests/test_api_security.py
@@ -195,3 +195,37 @@ def test_update_product_invalid_cas_rejected(client, db_session):
         json={"cas_number": "invalid-cas"},
     )
     assert resp.status_code == 422
+
+
+# --- XSS: API stores and returns raw strings (frontend must escape) ---
+
+
+def test_vendor_name_with_html_chars_stored_and_returned_raw(client):
+    """API must store vendor names verbatim (no server-side HTML escaping).
+
+    The frontend is responsible for escaping via escapeHtml(). The API
+    must NOT double-escape, so the raw '<script>' string must come back
+    unchanged from the API JSON response.
+    """
+    xss_name = '<script>alert("xss")</script>'
+    resp = client.post("/api/vendors/", json={"name": xss_name})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == xss_name, "API must return raw string, not HTML-escaped"
+
+    # Verify it round-trips through GET as well
+    vendor_id = data["id"]
+    get_resp = client.get(f"/api/vendors/{vendor_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["name"] == xss_name
+
+
+def test_product_name_with_html_chars_stored_raw(client):
+    """Product names with HTML chars must be preserved verbatim in API responses."""
+    xss_name = 'Reagent <b>bold</b> & "quoted"'
+    resp = client.post(
+        "/api/products/",
+        json={"catalog_number": "XSS-PROD-01", "name": xss_name},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["name"] == xss_name


### PR DESCRIPTION
## Summary

- **api.js**: fixed `escapeHtml()` null guard — changed `if (!s)` to `if (s == null || s === "")` so numeric `0` is not silently converted to `""` (falsy bug)
- **dashboard.js**: wrapped all card/alert template interpolations with `escapeHtml()`; used `parseInt()` for API count values in bar charts
- **orders.js** / **inventory.js**: `parseInt()` on `page` and `pages` from API before inserting into pagination HTML
- **tests**: 2 new tests in `test_api_security.py` verifying the API stores and returns HTML-special strings verbatim (escaping is the frontend's responsibility)
- **TODOS.md**: marks TODO-13 complete

Most API string values (vendor names, file names, document types, etc.) were already wrapped with `escapeHtml()` from prior work. This PR closes the remaining gaps.

## Test plan

- [x] `uv run pytest tests/test_api_security.py -v` — 16/16 pass
- [x] `uv run pytest --ignore=tests/bdd -q` — 255 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)