### PR TITLE
fix(setup): add email/name input validation

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -381,7 +381,24 @@ def create_app() -> FastAPI:
         from lab_manager.database import get_db_session
         from lab_manager.models.staff import Staff
 
-        # Validate before opening DB session
+        # Validate inputs before opening DB session
+        admin_name = admin_name.strip()
+        admin_email = admin_email.strip().lower()
+        if not admin_name or len(admin_name) > 200:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": "Name must be between 1 and 200 characters"},
+            )
+        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", admin_email):
+            return JSONResponse(
+                status_code=422,
+                content={"detail": "Invalid email address"},
+            )
+        if len(admin_email) > 255:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": "Email must be 255 characters or fewer"},
+            )
         if len(admin_password) < 8:
             return JSONResponse(
                 status_code=422,
@@ -429,7 +446,7 @@ def create_app() -> FastAPI:
                     content={"detail": "Setup already completed"},
                 )
 
-            logger.info("Setup complete: admin user created (%s)", admin_email)
+            logger.info("Setup complete: admin user created")
             return {
                 "status": "ok",
                 "message": "Admin account created. You can now sign in.",

--- a/tests/bdd/features/one_click_setup.feature
+++ b/tests/bdd/features/one_click_setup.feature
@@ -48,7 +48,19 @@ Feature: One-Click Lab Setup
     When I complete setup with name "Dr. Chen" email "chen@mgh.harvard.edu" and password "neuroscience2026"
     Then I should not receive a 401 unauthorized error
 
-  # === Password validation ===
+  # === Input validation ===
+
+  Scenario: Invalid email is rejected
+    Given a fresh Lab Manager instance with no users
+    When I complete setup with name "Dr. Chen" email "notanemail" and password "neuroscience2026"
+    Then the setup should fail with status 422
+    And the error should mention "Invalid email"
+
+  Scenario: Empty name is rejected
+    Given a fresh Lab Manager instance with no users
+    When I complete setup with name "   " email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    Then the setup should fail with status 422
+    And the error should mention "Name must be"
 
   Scenario: Password too short is rejected
     Given a fresh Lab Manager instance with no users

--- a/tests/bdd/step_defs/test_one_click_setup.py
+++ b/tests/bdd/step_defs/test_one_click_setup.py
@@ -51,6 +51,16 @@ def test_setup_no_auth():
     pass
 
 
+@scenario(FEATURE, "Invalid email is rejected")
+def test_invalid_email():
+    pass
+
+
+@scenario(FEATURE, "Empty name is rejected")
+def test_empty_name():
+    pass
+
+
 @scenario(FEATURE, "Password too short is rejected")
 def test_password_too_short():
     pass
@@ -184,7 +194,9 @@ def fresh_instance():
 
 
 @given(
-    parsers.parse('a Lab Manager instance with name "{name}" and subtitle "{subtitle}"'),
+    parsers.parse(
+        'a Lab Manager instance with name "{name}" and subtitle "{subtitle}"'
+    ),
     target_fixture="api",
 )
 def instance_with_branding(name, subtitle):
@@ -263,7 +275,11 @@ def request_config(api, ctx):
     ctx["response"] = api.get("/api/config")
 
 
-@when(parsers.parse('I complete setup with name "{name}" email "{email}" and password "{password}"'))
+@when(
+    parsers.parse(
+        'I complete setup with name "{name}" email "{email}" and password "{password}"'
+    )
+)
 def complete_setup(api, ctx, name, email, password):
     ctx["response"] = api.post(
         "/api/setup/complete",
@@ -288,7 +304,11 @@ def complete_setup_long_password(api, ctx):
     )
 
 
-@when(parsers.parse('I try to complete setup again with name "{name}" email "{email}" and password "{password}"'))
+@when(
+    parsers.parse(
+        'I try to complete setup again with name "{name}" email "{email}" and password "{password}"'
+    )
+)
 def try_setup_again(api, ctx, name, email, password):
     ctx["response"] = api.post(
         "/api/setup/complete",
@@ -400,7 +420,9 @@ def login_failed(ctx, status):
 def session_cookie_set(ctx):
     resp = ctx["response"]
     cookies = resp.headers.get_list("set-cookie")
-    assert any("lab_session" in c for c in cookies), "Expected lab_session cookie to be set"
+    assert any("lab_session" in c for c in cookies), (
+        "Expected lab_session cookie to be set"
+    )
 
 
 @then(parsers.parse('I should be recognized as "{name}"'))

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -178,6 +178,48 @@ def test_setup_complete_short_password_rejected(setup_client):
     assert resp.status_code == 422
 
 
+@pytest.mark.parametrize("bad_email", ["notanemail", "missing@domain", "@no-local.com"])
+def test_setup_complete_invalid_email_rejected(setup_client, bad_email):
+    """Invalid email format should be rejected."""
+    resp = setup_client.post(
+        "/api/setup/complete",
+        json={
+            "admin_name": "Dr. Smith",
+            "admin_email": bad_email,
+            "admin_password": "securepass123",
+        },
+    )
+    assert resp.status_code == 422, (
+        f"Expected 422 for email '{bad_email}', got {resp.status_code}"
+    )
+
+
+def test_setup_complete_empty_name_rejected(setup_client):
+    """Empty name should be rejected."""
+    resp = setup_client.post(
+        "/api/setup/complete",
+        json={
+            "admin_name": "   ",
+            "admin_email": "smith@mit.edu",
+            "admin_password": "securepass123",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_setup_complete_long_name_rejected(setup_client):
+    """Name exceeding 200 characters should be rejected."""
+    resp = setup_client.post(
+        "/api/setup/complete",
+        json={
+            "admin_name": "A" * 201,
+            "admin_email": "smith@mit.edu",
+            "admin_password": "securepass123",
+        },
+    )
+    assert resp.status_code == 422
+
+
 def test_setup_no_auth_required(setup_client):
     """Setup complete should be accessible without authentication."""
     resp = setup_client.post(


### PR DESCRIPTION
## Summary
- Validate email format (regex), name length (1-200), email length (≤255)
- Normalize email to lowercase, strip whitespace from name/email
- Remove admin email from log output (info leakage)

## Test plan
- [x] 32 tests pass (14 unit + 18 BDD)
- [x] Parametrized tests for invalid emails: `notanemail`, `missing@domain`, `@no-local.com`
- [x] Empty name and long name (201 chars) rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)