### PR TITLE
feat(ui): add confidence badges and sort to review queue

### DIFF
--- a/web/src/components/ui/ConfidenceBadge.tsx
+++ b/web/src/components/ui/ConfidenceBadge.tsx
@@ -1,0 +1,34 @@
+interface ConfidenceBadgeProps {
+  confidence: number | null | undefined
+}
+
+function getLevel(confidence: number | null | undefined) {
+  if (confidence == null) return { label: 'N/A', color: '#6B7280' }
+  const pct = confidence * 100
+  if (pct >= 95) return { label: 'High', color: '#00D4AA' }
+  if (pct >= 80) return { label: 'Medium', color: '#6C5CE7' }
+  if (pct >= 50) return { label: 'Low', color: '#F39C12' }
+  return { label: 'Needs Review', color: '#E74C3C' }
+}
+
+export function ConfidenceBadge({ confidence }: ConfidenceBadgeProps) {
+  const { label, color } = getLevel(confidence)
+  const pct = confidence != null ? `${(confidence * 100).toFixed(0)}%` : '—'
+
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-semibold"
+      style={{
+        backgroundColor: `${color}18`,
+        color,
+        border: `1px solid ${color}40`,
+      }}
+    >
+      <span
+        className="w-1.5 h-1.5 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      {pct} {label}
+    </span>
+  )
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,7 @@ export interface Document {
   created_at?: string
   review_status?: string
   source_url?: string
+  extraction_confidence?: number | null
 }
 
 export interface DashboardStats {

--- a/web/src/pages/ReviewPage.tsx
+++ b/web/src/pages/ReviewPage.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { documents as docApi } from '@/lib/api'
 import type { Document } from '@/lib/api'
 import { CheckCircle2, XCircle, AlertTriangle, RefreshCw, ClipboardCheck } from 'lucide-react'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ConfidenceBadge } from '@/components/ui/ConfidenceBadge'
 
 interface ReviewPageProps {
   onError?: (error: string) => void
@@ -29,6 +30,14 @@ export function ReviewPage({ onError }: ReviewPageProps) {
   useEffect(() => {
     loadQueue()
   }, [])
+
+  const sortedQueue = useMemo(() => {
+    return [...queue].sort((a, b) => {
+      const aVal = a.extraction_confidence ?? 1
+      const bVal = b.extraction_confidence ?? 1
+      return aVal - bVal
+    })
+  }, [queue])
 
   const handleAction = async () => {
     if (!action) return
@@ -81,7 +90,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
         </button>
       </div>
 
-      {queue.map((doc) => (
+      {sortedQueue.map((doc) => (
         <div key={doc.id} className="card">
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 space-y-2">
@@ -92,6 +101,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 <span className="badge badge-info">
                   {doc.document_type ?? 'Unknown'}
                 </span>
+                <ConfidenceBadge confidence={doc.extraction_confidence} />
               </div>
               <p className="text-sm text-[var(--muted-foreground)]">
                 Vendor: {doc.vendor_name ?? 'Unknown'}


### PR DESCRIPTION
## Summary
- Add 4-level confidence badges (teal/indigo/amber/red) per DESIGN.md
- Sort review queue by confidence ascending (lowest first)
- New reusable ConfidenceBadge component

## Test plan
- [x] All existing tests pass (761 passed)
- [ ] Confidence badges show correct colors at threshold boundaries
- [ ] Review queue sorts lowest confidence first by default