### PR TITLE
fix(api): add IntegrityError handler and input validation

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -16,6 +16,7 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
 
 # Import to register SQLAlchemy event listeners on module load.
 import lab_manager.services.audit as _audit_svc  # noqa: F401
@@ -126,6 +127,14 @@ def create_app() -> FastAPI:
         return JSONResponse(
             status_code=exc.status_code,
             content={"detail": exc.message},
+        )
+
+    # --- SQLAlchemy IntegrityError → 409 Conflict ---
+    @app.exception_handler(IntegrityError)
+    async def _integrity_error_handler(request: Request, exc: IntegrityError):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "Resource conflict: duplicate or constraint violation"},
         )
 
     # --- Audit middleware (inner — registered first) ---
@@ -385,7 +394,6 @@ def create_app() -> FastAPI:
     ):
         """First-run setup: create the admin user. Only works when no admin exists."""
         import bcrypt as _bcrypt
-        from sqlalchemy.exc import IntegrityError
 
         from lab_manager.database import get_db_session
         from lab_manager.models.staff import Staff

--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -6,7 +6,7 @@ from datetime import date
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from lab_manager.api.deps import get_db, get_or_404
@@ -36,29 +36,47 @@ _INV_SORTABLE = {
 class InventoryItemCreate(BaseModel):
     product_id: Optional[int] = None
     location_id: Optional[int] = None
-    lot_number: Optional[str] = None
+    lot_number: Optional[str] = Field(default=None, max_length=100)
     quantity_on_hand: float = 0
-    unit: Optional[str] = None
+    unit: Optional[str] = Field(default=None, max_length=50)
     expiry_date: Optional[date] = None
     opened_date: Optional[date] = None
     status: str = InventoryStatus.available
-    notes: Optional[str] = None
-    received_by: Optional[str] = None
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    received_by: Optional[str] = Field(default=None, max_length=200)
     order_item_id: Optional[int] = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        valid = {s.value for s in InventoryStatus}
+        if v not in valid:
+            raise ValueError(f"status must be one of {valid}")
+        return v
 
 
 class InventoryItemUpdate(BaseModel):
     product_id: Optional[int] = None
     location_id: Optional[int] = None
-    lot_number: Optional[str] = None
+    lot_number: Optional[str] = Field(default=None, max_length=100)
     quantity_on_hand: Optional[float] = None
-    unit: Optional[str] = None
+    unit: Optional[str] = Field(default=None, max_length=50)
     expiry_date: Optional[date] = None
     opened_date: Optional[date] = None
     status: Optional[str] = None
-    notes: Optional[str] = None
-    received_by: Optional[str] = None
+    notes: Optional[str] = Field(default=None, max_length=2000)
+    received_by: Optional[str] = Field(default=None, max_length=200)
     order_item_id: Optional[int] = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        valid = {s.value for s in InventoryStatus}
+        if v not in valid:
+            raise ValueError(f"status must be one of {valid}")
+        return v
 
 
 class ConsumeBody(BaseModel):

--- a/src/lab_manager/api/routes/orders.py
+++ b/src/lab_manager/api/routes/orders.py
@@ -6,7 +6,7 @@ from datetime import date, datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.orm import Session
 
 from lab_manager.api.deps import get_db, get_or_404
@@ -46,15 +46,15 @@ _ORDER_SORTABLE = {
 
 
 class OrderCreate(BaseModel):
-    po_number: Optional[str] = None
+    po_number: Optional[str] = Field(default=None, max_length=100)
     vendor_id: Optional[int] = None
     order_date: Optional[date] = None
     ship_date: Optional[date] = None
     received_date: Optional[date] = None
-    received_by: Optional[str] = None
+    received_by: Optional[str] = Field(default=None, max_length=200)
     status: str = OrderStatus.pending
-    delivery_number: Optional[str] = None
-    invoice_number: Optional[str] = None
+    delivery_number: Optional[str] = Field(default=None, max_length=100)
+    invoice_number: Optional[str] = Field(default=None, max_length=100)
     document_id: Optional[int] = None
     extra: dict = {}
 
@@ -68,17 +68,27 @@ class OrderCreate(BaseModel):
 
 
 class OrderUpdate(BaseModel):
-    po_number: Optional[str] = None
+    po_number: Optional[str] = Field(default=None, max_length=100)
     vendor_id: Optional[int] = None
     order_date: Optional[date] = None
     ship_date: Optional[date] = None
     received_date: Optional[date] = None
-    received_by: Optional[str] = None
+    received_by: Optional[str] = Field(default=None, max_length=200)
     status: Optional[str] = None
-    delivery_number: Optional[str] = None
-    invoice_number: Optional[str] = None
+    delivery_number: Optional[str] = Field(default=None, max_length=100)
+    invoice_number: Optional[str] = Field(default=None, max_length=100)
     document_id: Optional[int] = None
     extra: Optional[dict] = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str | None) -> str | None:
+        if v is None:
+            return v
+        valid_statuses = {s.value for s in OrderStatus}
+        if v not in valid_statuses:
+            raise ValueError(f"status must be one of {valid_statuses}")
+        return v
 
 
 # --- OrderItem schemas ---

--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -23,21 +23,21 @@ _VENDOR_SORTABLE = {"id", "created_at", "updated_at", "name", "email", "website"
 
 
 class VendorCreate(BaseModel):
-    name: str
+    name: str = Field(max_length=200)
     aliases: list[str] = []
-    website: Optional[str] = None
-    phone: Optional[str] = None
-    email: Optional[str] = None
-    notes: Optional[str] = None
+    website: Optional[str] = Field(default=None, max_length=500)
+    phone: Optional[str] = Field(default=None, max_length=50)
+    email: Optional[str] = Field(default=None, max_length=255)
+    notes: Optional[str] = Field(default=None, max_length=2000)
 
 
 class VendorUpdate(BaseModel):
-    name: Optional[str] = None
+    name: Optional[str] = Field(default=None, max_length=200)
     aliases: Optional[list[str]] = None
-    website: Optional[str] = None
-    phone: Optional[str] = None
-    email: Optional[str] = None
-    notes: Optional[str] = None
+    website: Optional[str] = Field(default=None, max_length=500)
+    phone: Optional[str] = Field(default=None, max_length=50)
+    email: Optional[str] = Field(default=None, max_length=255)
+    notes: Optional[str] = Field(default=None, max_length=2000)
 
 
 class VendorResponse(BaseModel):


### PR DESCRIPTION
## Summary
- Add global `IntegrityError` exception handler returning 409 Conflict instead of 500 for duplicate/constraint violations across all routes
- Add `max_length` constraints to Pydantic schemas: vendors (name=200, email=255, phone=50, website=500, notes=2000), orders (po_number/delivery/invoice=100, received_by=200), inventory (lot_number=100, unit=50, notes=2000, received_by=200)
- Add `field_validator` for status fields in `InventoryItemUpdate` and `OrderUpdate` to validate against enum values before DB write

## Test plan
- [x] All 761 existing tests pass
- [ ] Verify 409 response on duplicate vendor creation
- [ ] Verify 422 response on overly long string inputs
- [ ] Verify 422 response on invalid status values

🤖 Generated with [Claude Code](https://claude.com/claude-code)