### PR TITLE
fix(db): use flush() instead of commit() in routes

### DIFF
--- a/src/lab_manager/api/routes/alerts.py
+++ b/src/lab_manager/api/routes/alerts.py
@@ -74,7 +74,7 @@ def acknowledge_alert(
     alert.is_acknowledged = True
     alert.acknowledged_by = acknowledged_by
     alert.acknowledged_at = utcnow()
-    db.commit()
+    db.flush()
     db.refresh(alert)
     return alert
 
@@ -90,6 +90,6 @@ def resolve_alert(
     if not alert.is_acknowledged:
         alert.is_acknowledged = True
         alert.acknowledged_at = utcnow()
-    db.commit()
+    db.flush()
     db.refresh(alert)
     return alert

--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -169,7 +169,7 @@ def upload_document(
         status=DocumentStatus.pending,
     )
     db.add(doc)
-    db.commit()
+    db.flush()
     db.refresh(doc)
     return doc
 
@@ -245,7 +245,7 @@ def list_documents(
 def create_document(body: DocumentCreate, db: Session = Depends(get_db)):
     document = Document(**body.model_dump())
     db.add(document)
-    db.commit()
+    db.flush()
     db.refresh(document)
     return document
 
@@ -263,7 +263,7 @@ def update_document(
     doc = get_or_404(db, Document, document_id, "Document")
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(doc, key, value)
-    db.commit()
+    db.flush()
     db.refresh(doc)
     return doc
 
@@ -273,7 +273,7 @@ def delete_document(document_id: int, db: Session = Depends(get_db)):
     """Soft-delete: set status to 'deleted'."""
     doc = get_or_404(db, Document, document_id, "Document")
     doc.status = DocumentStatus.deleted
-    db.commit()
+    db.flush()
     return None
 
 
@@ -297,7 +297,7 @@ def review_document(
         doc.reviewed_by = body.reviewed_by
         doc.review_notes = body.review_notes
 
-    db.commit()
+    db.flush()
     db.refresh(doc)
     return doc
 

--- a/src/lab_manager/api/routes/equipment.py
+++ b/src/lab_manager/api/routes/equipment.py
@@ -99,7 +99,7 @@ def list_equipment(
 def create_equipment(body: EquipmentCreate, db: Session = Depends(get_db)):
     equip = Equipment(**body.model_dump())
     db.add(equip)
-    db.commit()
+    db.flush()
     db.refresh(equip)
     return equip
 
@@ -116,7 +116,7 @@ def update_equipment(
     equip = get_or_404(db, Equipment, equipment_id, "Equipment")
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(equip, key, value)
-    db.commit()
+    db.flush()
     db.refresh(equip)
     return equip
 
@@ -125,6 +125,6 @@ def update_equipment(
 def delete_equipment(equipment_id: int, db: Session = Depends(get_db)):
     equip = get_or_404(db, Equipment, equipment_id, "Equipment")
     equip.status = EquipmentStatus.deleted
-    db.commit()
+    db.flush()
     db.refresh(equip)
     return equip

--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -127,7 +127,7 @@ def list_inventory(
 def create_inventory_item(body: InventoryItemCreate, db: Session = Depends(get_db)):
     item = InventoryItem(**body.model_dump())
     db.add(item)
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -161,7 +161,7 @@ def update_inventory_item(
     item = get_or_404(db, InventoryItem, item_id, "Inventory item")
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(item, key, value)
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -171,7 +171,7 @@ def delete_inventory_item(item_id: int, db: Session = Depends(get_db)):
     """Soft-delete: set status to 'deleted'."""
     item = get_or_404(db, InventoryItem, item_id, "Inventory item")
     item.status = InventoryStatus.deleted
-    db.commit()
+    db.flush()
     return None
 
 

--- a/src/lab_manager/api/routes/orders.py
+++ b/src/lab_manager/api/routes/orders.py
@@ -167,7 +167,7 @@ def list_orders(
 def create_order(body: OrderCreate, db: Session = Depends(get_db)):
     order = Order(**body.model_dump())
     db.add(order)
-    db.commit()
+    db.flush()
     db.refresh(order)
 
     # Duplicate PO# check — warn but never block (OCR may re-scan same doc).
@@ -199,7 +199,7 @@ def update_order(order_id: int, body: OrderUpdate, db: Session = Depends(get_db)
     order = get_or_404(db, Order, order_id, "Order")
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(order, key, value)
-    db.commit()
+    db.flush()
     db.refresh(order)
     return order
 
@@ -209,7 +209,7 @@ def delete_order(order_id: int, db: Session = Depends(get_db)):
     """Soft-delete: set status to 'deleted'."""
     order = get_or_404(db, Order, order_id, "Order")
     order.status = OrderStatus.deleted
-    db.commit()
+    db.flush()
     return None
 
 
@@ -245,7 +245,7 @@ def create_order_item(
     item = OrderItem(**body.model_dump())
     item.order_id = order_id
     db.add(item)
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -262,7 +262,7 @@ def update_order_item(
     item = _get_order_item_or_raise(db, order_id, item_id)
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(item, key, value)
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -271,7 +271,7 @@ def update_order_item(
 def delete_order_item(order_id: int, item_id: int, db: Session = Depends(get_db)):
     item = _get_order_item_or_raise(db, order_id, item_id)
     db.delete(item)
-    db.commit()
+    db.flush()
     return None
 
 

--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -82,7 +82,7 @@ def list_vendors(
 def create_vendor(body: VendorCreate, db: Session = Depends(get_db)):
     vendor = Vendor(**body.model_dump())
     db.add(vendor)
-    db.commit()
+    db.flush()
     db.refresh(vendor)
     return vendor
 
@@ -97,7 +97,7 @@ def update_vendor(vendor_id: int, body: VendorUpdate, db: Session = Depends(get_
     vendor = get_or_404(db, Vendor, vendor_id, "Vendor")
     for key, value in body.model_dump(exclude_unset=True).items():
         setattr(vendor, key, value)
-    db.commit()
+    db.flush()
     db.refresh(vendor)
     return vendor
 
@@ -107,7 +107,7 @@ def delete_vendor(vendor_id: int, db: Session = Depends(get_db)):
     vendor = get_or_404(db, Vendor, vendor_id, "Vendor")
     try:
         db.delete(vendor)
-        db.commit()
+        db.flush()
     except IntegrityError:
         db.rollback()
         raise ConflictError(

--- a/src/lab_manager/services/inventory.py
+++ b/src/lab_manager/services/inventory.py
@@ -120,7 +120,7 @@ def receive_items(
     order.received_date = today
     order.received_by = received_by
 
-    db.commit()
+    db.flush()
     for inv in created:
         db.refresh(inv)
     return created
@@ -166,7 +166,7 @@ def consume(
         action=ConsumptionAction.consume,
         purpose=purpose,
     )
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -197,7 +197,7 @@ def transfer(
         action=ConsumptionAction.transfer,
         purpose=f"Moved from location {old_location_id} to {new_location_id}",
     )
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -238,7 +238,7 @@ def adjust(
         action=ConsumptionAction.adjust,
         purpose=f"Cycle count: {old_quantity} -> {new_quantity}. Reason: {reason}",
     )
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -271,7 +271,7 @@ def dispose(
         action=ConsumptionAction.dispose,
         purpose=reason,
     )
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 
@@ -305,7 +305,7 @@ def open_item(
         action=ConsumptionAction.open,
         purpose="Item opened",
     )
-    db.commit()
+    db.flush()
     db.refresh(item)
     return item
 

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -653,7 +653,7 @@ class TestVendorRoutes:
             with patch.object(db_session, "delete", side_effect=None):
                 with patch.object(
                     db_session,
-                    "commit",
+                    "flush",
                     side_effect=IntegrityError("", {}, Exception()),
                 ):
                     resp = client.delete(f"/api/v1/vendors/{vid}")


### PR DESCRIPTION
## Summary
- Replace `db.commit()` with `db.flush()` in all API route files (vendors, orders, inventory, documents, alerts, equipment) and `services/inventory.py`
- `flush()` sends SQL to the DB and populates generated IDs without committing — the `get_db()` dependency handles the final commit/rollback
- Update test mock in `test_coverage_gaps.py` to patch `flush` instead of `commit`

**Why**: Routes calling `db.commit()` mid-request break single-commit-per-request atomicity. If anything fails after a manual commit, the earlier writes can't be rolled back.

## Test plan
- [x] `uv run pytest tests/ -x -q` — all 437 tests pass
- [x] No new warnings introduced
- [ ] Verify no unintended side effects on existing API behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)