### PR TITLE
perf(db): add eager loading to prevent N+1 queries

### DIFF
--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate
@@ -105,7 +105,7 @@ def list_inventory(
     sort_dir: str = Query("asc", pattern="^(asc|desc)$"),
     db: Session = Depends(get_db),
 ):
-    q = db.query(InventoryItem)
+    q = db.query(InventoryItem).options(selectinload(InventoryItem.product))
     if product_id is not None:
         q = q.filter(InventoryItem.product_id == product_id)
     if location_id is not None:

--- a/src/lab_manager/api/routes/orders.py
+++ b/src/lab_manager/api/routes/orders.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, field_validator
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate
@@ -146,7 +146,7 @@ def list_orders(
     sort_dir: str = Query("asc", pattern="^(asc|desc)$"),
     db: Session = Depends(get_db),
 ):
-    q = db.query(Order)
+    q = db.query(Order).options(selectinload(Order.vendor), selectinload(Order.items))
     if vendor_id is not None:
         q = q.filter(Order.vendor_id == vendor_id)
     if status:

--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field as PydanticField, field_validator
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate
@@ -110,7 +110,7 @@ def list_products(
     sort_dir: str = Query("asc", pattern="^(asc|desc)$"),
     db: Session = Depends(get_db),
 ):
-    q = db.query(Product)
+    q = db.query(Product).options(selectinload(Product.vendor))
     if not include_inactive:
         q = q.filter(Product.is_active == True)  # noqa: E712
     if vendor_id is not None:

--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate
@@ -65,7 +65,7 @@ def list_vendors(
     sort_dir: str = Query("asc", pattern="^(asc|desc)$"),
     db: Session = Depends(get_db),
 ):
-    q = db.query(Vendor)
+    q = db.query(Vendor).options(selectinload(Vendor.products))
     if name:
         q = q.filter(ilike_col(Vendor.name, name))
     if search:

--- a/src/lab_manager/services/inventory.py
+++ b/src/lab_manager/services/inventory.py
@@ -78,12 +78,23 @@ def receive_items(
     if not order:
         raise NotFoundError("Order", order_id)
 
+    # Batch-fetch all order items to avoid N+1 queries.
+    item_ids = [
+        ri.get("order_item_id") for ri in items_received if ri.get("order_item_id")
+    ]
+    items_map: dict[int, OrderItem] = {}
+    if item_ids:
+        items_map = {
+            i.id: i
+            for i in db.query(OrderItem).filter(OrderItem.id.in_(item_ids)).all()
+        }
+
     created = []
     today = date.today()
 
     for ri in items_received:
         order_item_id = ri.get("order_item_id")
-        order_item = db.get(OrderItem, order_item_id) if order_item_id else None
+        order_item = items_map.get(order_item_id) if order_item_id else None
         if order_item and order_item.order_id != order_id:
             raise ValidationError(
                 f"Order item {order_item_id} belongs to order {order_item.order_id}, not {order_id}"


### PR DESCRIPTION
## Summary
- Add `selectinload` to 4 list endpoints (inventory, orders, vendors, products) to preload relationships
- Batch-fetch order items in `receive_items()` instead of individual `db.get()` calls

## Problem
All SQLModel relationships use default lazy loading. List endpoints return ORM objects that trigger N+1 queries when serialized — e.g., listing 50 orders each with a vendor and items = 101+ queries instead of 3.

## Changes
| Endpoint | Eager-loaded relationships |
|----------|--------------------------|
| `GET /api/inventory/` | `InventoryItem.product` |
| `GET /api/orders/` | `Order.vendor`, `Order.items` |
| `GET /api/vendors/` | `Vendor.products` |
| `GET /api/products/` | `Product.vendor` |
| `POST /api/orders/{id}/receive` | Batch `OrderItem` fetch |

## Test plan
- [x] All 761 existing tests pass
- [x] No API contract changes (same response shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)