### PR TITLE
fix(deploy): SCANS_DIR config and frontend build in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+# Stage 1: Build React frontend
+FROM node:22-alpine AS frontend
+WORKDIR /app/web
+COPY web/package.json web/bun.lock ./
+RUN npm ci
+COPY web/ ./
+RUN npm run build
+
+# Stage 2: Python application
 FROM python:3.12-slim
 
 WORKDIR /app
@@ -8,6 +17,7 @@ RUN pip install uv==0.7.12 \
 
 COPY pyproject.toml uv.lock ./
 COPY src/ src/
+COPY --from=frontend /app/src/lab_manager/static/dist src/lab_manager/static/dist
 RUN uv sync --frozen --no-dev
 
 COPY alembic/ alembic/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,8 @@ services:
       EXTRACTION_MODEL: ${EXTRACTION_MODEL:-gemini-3.1-flash-preview}
       RAG_MODEL: ${RAG_MODEL:-gemini-2.5-flash}
       UPLOAD_DIR: /app/uploads
+      SCANS_DIR: ${SCANS_DIR:-/app/shenlab-docs}
+      DEVICES_DIR: ${DEVICES_DIR:-/app/shenlab-devices}
     depends_on:
       db:
         condition: service_healthy

--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -29,8 +29,23 @@ configure_logging()
 logger = logging.getLogger(__name__)
 
 STATIC_DIR = Path(__file__).parent.parent / "static"
-SCANS_DIR = Path(__file__).resolve().parent.parent.parent.parent / "shenlab-docs"
-DEVICES_DIR = Path(__file__).resolve().parent.parent.parent.parent / "shenlab-devices"
+
+
+def _get_scans_dir() -> Path:
+    """Return scans directory from config or fall back to default path."""
+    settings = get_settings()
+    if settings.scans_dir:
+        return Path(settings.scans_dir)
+    return Path(__file__).resolve().parent.parent.parent.parent / "shenlab-docs"
+
+
+def _get_devices_dir() -> Path:
+    """Return devices directory from config or fall back to default path."""
+    settings = get_settings()
+    if settings.devices_dir:
+        return Path(settings.devices_dir)
+    return Path(__file__).resolve().parent.parent.parent.parent / "shenlab-devices"
+
 
 # Strip control characters from X-User header to prevent log injection.
 _CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
@@ -518,8 +533,9 @@ def create_app() -> FastAPI:
                 route.endpoint = limiter.limit("10/minute")(original_endpoint)
 
     # Serve scan images (protected by auth middleware when auth is enabled)
-    if SCANS_DIR.exists():  # pragma: no cover — depends on deployment
-        app.mount("/scans", StaticFiles(directory=str(SCANS_DIR)), name="scans")
+    scans_dir = _get_scans_dir()
+    if scans_dir.exists():  # pragma: no cover — depends on deployment
+        app.mount("/scans", StaticFiles(directory=str(scans_dir)), name="scans")
 
     # Serve uploaded documents at /uploads/
     upload_path = Path(settings.upload_dir)
@@ -531,9 +547,11 @@ def create_app() -> FastAPI:
     )
 
     # Serve device photos
-    if DEVICES_DIR.exists():  # pragma: no cover — depends on deployment
+    if _get_devices_dir().exists():  # pragma: no cover — depends on deployment
         app.mount(
-            "/lab-devices", StaticFiles(directory=str(DEVICES_DIR)), name="devices"
+            "/lab-devices",
+            StaticFiles(directory=str(_get_devices_dir())),
+            name="devices",
         )
 
     # Wire up SQLAdmin UI at /admin/


### PR DESCRIPTION
## Summary
- Replace hardcoded `SCANS_DIR`/`DEVICES_DIR` path resolution with config-driven helpers (`_get_scans_dir`, `_get_devices_dir`) that read from `Settings` with backward-compatible fallback
- Add multi-stage Dockerfile: Node 22 builds React frontend in stage 1, Python 3.12 copies `dist/` in stage 2 — no Node runtime in final image
- Pass `SCANS_DIR` and `DEVICES_DIR` env vars in `docker-compose.yml` so the app can find mounted volumes

## Test plan
- [x] `uv run pytest tests/ -x -q` — 761 passed, 11 skipped
- [ ] `docker compose build app` — verify React build succeeds and dist/ is copied
- [ ] `docker compose up -d app` — verify frontend loads at `/` and scans serve at `/scans/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)