### PR TITLE
feat(ui): add empty, error, and loading states to all pages

### DIFF
--- a/web/src/components/ui/SkeletonTable.tsx
+++ b/web/src/components/ui/SkeletonTable.tsx
@@ -1,0 +1,26 @@
+interface SkeletonTableProps {
+  columns: number
+  rows?: number
+}
+
+export function SkeletonTable({ columns, rows = 5 }: SkeletonTableProps) {
+  return (
+    <tbody>
+      {Array.from({ length: rows }).map((_, i) => (
+        <tr
+          key={i}
+          className="border-b border-[var(--border)] last:border-0"
+        >
+          {Array.from({ length: columns }).map((_, j) => (
+            <td key={j} className="px-4 py-3">
+              <div
+                className="h-4 rounded bg-[var(--muted)] animate-pulse"
+                style={{ width: j === 0 ? '60%' : '40%', animationDelay: `${(i * columns + j) * 75}ms` }}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </tbody>
+  )
+}

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { analytics } from '@/lib/api'
+import { Link } from 'react-router-dom'
 import {
   FileText,
   CheckCircle2,
@@ -9,7 +10,12 @@ import {
   Store,
   TrendingUp,
   Package,
+  Upload,
+  RefreshCw,
+  LayoutDashboard,
+  WifiOff,
 } from 'lucide-react'
+import { EmptyState } from '@/components/ui/EmptyState'
 
 interface DocStats {
   total_documents: number
@@ -45,18 +51,57 @@ export function DashboardPage({ onError }: DashboardPageProps) {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="w-8 h-8 border-2 border-[var(--primary)]/30 border-t-[var(--primary)] rounded-full animate-spin" />
+      <div className="space-y-6">
+        <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="card">
+              <div className="flex items-center gap-3 mb-3">
+                <div className="w-8 h-8 rounded-lg bg-[var(--muted)] animate-pulse" />
+                <div className="h-3 w-24 rounded bg-[var(--muted)] animate-pulse" />
+              </div>
+              <div className="h-7 w-16 rounded bg-[var(--muted)] animate-pulse" />
+              <div className="h-3 w-32 rounded bg-[var(--muted)] animate-pulse mt-2" />
+            </div>
+          ))}
+        </div>
       </div>
     )
   }
 
-  if (!stats) {
+  if (error) {
     return (
-      <div className="text-center py-16 text-[var(--muted-foreground)]">
-        Failed to load dashboard data.
-      </div>
+      <EmptyState
+        icon={WifiOff}
+        title="Could not load dashboard data"
+        description="Check your connection and try again."
+        action={
+          <button onClick={() => window.location.reload()} className="btn-primary flex items-center gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+        }
+      />
     )
+  }
+
+  if (stats && stats.total_documents === 0 && stats.total_orders === 0 && stats.total_vendors === 0) {
+    return (
+      <EmptyState
+        icon={LayoutDashboard}
+        title="Welcome to Lab Manager"
+        description="Upload your first document to get started."
+        action={
+          <Link to="/documents" className="btn-primary flex items-center gap-2">
+            <Upload className="w-4 h-4" />
+            Upload Document
+          </Link>
+        }
+      />
+    )
+  }
+
+  if (!stats) {
+    return null
   }
 
   const cards = [

--- a/web/src/pages/DocumentsPage.tsx
+++ b/web/src/pages/DocumentsPage.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { documents as docApi } from '@/lib/api'
 import type { Document } from '@/lib/api'
-import { Search, ChevronLeft, ChevronRight, RefreshCw, FileText } from 'lucide-react'
+import { Search, ChevronLeft, ChevronRight, RefreshCw, FileText, Upload, WifiOff } from 'lucide-react'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { SkeletonTable } from '@/components/ui/SkeletonTable'
+import { Link } from 'react-router-dom'
 
 interface DocumentsPageProps {
   onError?: (error: string) => void
@@ -42,6 +44,22 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
   }
 
   const totalPages = Math.ceil(total / pageSize)
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={WifiOff}
+        title="Could not load documents"
+        description="Check your connection and try again."
+        action={
+          <button onClick={() => refetch()} className="btn-primary flex items-center gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+        }
+      />
+    )
+  }
 
   return (
     <div className="space-y-4">
@@ -88,6 +106,9 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               </th>
             </tr>
           </thead>
+          {isLoading ? (
+            <SkeletonTable columns={5} rows={5} />
+          ) : docs.length === 0 ? null : (
           <tbody>
             {docs.map((doc) => (
               <tr
@@ -118,22 +139,26 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               </tr>
             ))}
           </tbody>
+          )}
         </table>
 
-        {docs.length === 0 && (
+        {!isLoading && docs.length === 0 && (
           <div className="py-12">
-            {isLoading ? (
-              <div className="flex flex-col items-center justify-center space-y-3">
-                <div className="w-8 h-8 border-2 border-[var(--primary)]/30 border-t-[var(--primary)] rounded-full animate-spin" />
-                <span className="text-sm text-[var(--muted-foreground)] font-medium">Fetching documents...</span>
-              </div>
-            ) : (
-              <EmptyState
-                icon={FileText}
-                title={search ? "No matching documents" : "No documents found"}
-                description={search ? `No documents found matching "${search}"` : "You haven't uploaded any documents yet."}
-              />
-            )}
+            <EmptyState
+              icon={FileText}
+              title={search ? "No matching documents" : "No documents uploaded yet"}
+              description={search
+                ? `No documents found matching "${search}"`
+                : "Upload your first document to get started."}
+              action={
+                search ? undefined : (
+                  <Link to="/documents" className="btn-primary flex items-center gap-2">
+                    <Upload className="w-4 h-4" />
+                    Upload Document
+                  </Link>
+                )
+              }
+            />
           </div>
         )}
       </div>

--- a/web/src/pages/InventoryPage.tsx
+++ b/web/src/pages/InventoryPage.tsx
@@ -2,8 +2,10 @@ import { useState, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { inventory as invApi } from '@/lib/api'
 import type { InventoryItem } from '@/lib/api'
-import { RefreshCw, Search, ChevronLeft, ChevronRight, PackageSearch } from 'lucide-react'
+import { RefreshCw, Search, ChevronLeft, ChevronRight, PackageSearch, ClipboardCheck, WifiOff } from 'lucide-react'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { SkeletonTable } from '@/components/ui/SkeletonTable'
+import { Link } from 'react-router-dom'
 
 interface InventoryPageProps {
   onError?: (error: string) => void
@@ -44,6 +46,22 @@ export function InventoryPage({ onError }: InventoryPageProps) {
   }
 
   const totalPages = Math.ceil(total / pageSize)
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={WifiOff}
+        title="Could not load inventory"
+        description="Check your connection and try again."
+        action={
+          <button onClick={() => refetch()} className="btn-primary flex items-center gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+        }
+      />
+    )
+  }
 
   return (
     <div className="space-y-4">
@@ -88,6 +106,9 @@ export function InventoryPage({ onError }: InventoryPageProps) {
               </th>
             </tr>
           </thead>
+          {isLoading ? (
+            <SkeletonTable columns={6} rows={5} />
+          ) : items.length === 0 ? null : (
           <tbody>
             {items.map((item) => (
               <tr
@@ -121,22 +142,26 @@ export function InventoryPage({ onError }: InventoryPageProps) {
               </tr>
             ))}
           </tbody>
+          )}
         </table>
 
-        {items.length === 0 && (
+        {!isLoading && items.length === 0 && (
           <div className="py-12">
-            {isLoading ? (
-              <div className="flex flex-col items-center justify-center space-y-3">
-                <div className="w-8 h-8 border-2 border-[var(--primary)]/30 border-t-[var(--primary)] rounded-full animate-spin" />
-                <span className="text-sm text-[var(--muted-foreground)] font-medium">Fetching inventory...</span>
-              </div>
-            ) : (
-              <EmptyState
-                icon={PackageSearch}
-                title={search ? "No matching items" : "No inventory items"}
-                description={search ? `No items found matching "${search}"` : "Your laboratory inventory is currently empty."}
-              />
-            )}
+            <EmptyState
+              icon={PackageSearch}
+              title={search ? "No matching items" : "Your inventory is empty"}
+              description={search
+                ? `No items found matching "${search}"`
+                : "Process documents through the review queue to populate it."}
+              action={
+                search ? undefined : (
+                  <Link to="/review" className="btn-primary flex items-center gap-2">
+                    <ClipboardCheck className="w-4 h-4" />
+                    Go to Review Queue
+                  </Link>
+                )
+              }
+            />
           </div>
         )}
       </div>

--- a/web/src/pages/OrdersPage.tsx
+++ b/web/src/pages/OrdersPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
 import { orders as ordApi } from '@/lib/api'
 import type { Order } from '@/lib/api'
-import { Search, ChevronLeft, ChevronRight, RefreshCw, ShoppingCart } from 'lucide-react'
+import { Search, ChevronLeft, ChevronRight, RefreshCw, ShoppingCart, WifiOff, ClipboardCheck } from 'lucide-react'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { SkeletonTable } from '@/components/ui/SkeletonTable'
+import { Link } from 'react-router-dom'
 
 const STATUS_FILTERS = [
   { value: '', label: 'All Status' },
@@ -22,16 +24,19 @@ export function OrdersPage({ onError }: OrdersPageProps) {
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState('')
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const pageSize = 25
 
   const loadOrders = async () => {
     setLoading(true)
+    setLoadError(false)
     try {
       const res = await ordApi.list(page, pageSize)
       setOrders(res.items ?? [])
       setTotal(res.total ?? 0)
     } catch (err) {
       console.error('Failed to load orders:', err)
+      setLoadError(true)
     } finally {
       setLoading(false)
     }
@@ -70,6 +75,22 @@ export function OrdersPage({ onError }: OrdersPageProps) {
   }
 
   const totalPages = Math.ceil(total / pageSize)
+
+  if (loadError && !loading) {
+    return (
+      <EmptyState
+        icon={WifiOff}
+        title="Could not load orders"
+        description="Check your connection and try again."
+        action={
+          <button onClick={loadOrders} className="btn-primary flex items-center gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+        }
+      />
+    )
+  }
 
   return (
     <div className="space-y-4">
@@ -127,6 +148,9 @@ export function OrdersPage({ onError }: OrdersPageProps) {
               </th>
             </tr>
           </thead>
+          {loading ? (
+            <SkeletonTable columns={6} rows={5} />
+          ) : filtered.length === 0 ? null : (
           <tbody>
             {filtered.map((order) => (
               <tr
@@ -164,22 +188,26 @@ export function OrdersPage({ onError }: OrdersPageProps) {
               </tr>
             ))}
           </tbody>
+          )}
         </table>
 
-        {filtered.length === 0 && (
+        {!loading && filtered.length === 0 && (
           <div className="py-12">
-            {loading ? (
-              <div className="flex flex-col items-center justify-center space-y-3">
-                <div className="w-8 h-8 border-2 border-[var(--primary)]/30 border-t-[var(--primary)] rounded-full animate-spin" />
-                <span className="text-sm text-[var(--muted-foreground)] font-medium">Fetching orders...</span>
-              </div>
-            ) : (
-              <EmptyState
-                icon={ShoppingCart}
-                title={search ? "No matching orders" : "No orders found"}
-                description={search ? `No orders found matching "${search}"` : "You haven't placed any orders yet."}
-              />
-            )}
+            <EmptyState
+              icon={ShoppingCart}
+              title={search ? "No matching orders" : "No orders yet"}
+              description={search
+                ? `No orders found matching "${search}"`
+                : "Orders are created when documents are approved in the review queue."}
+              action={
+                search ? undefined : (
+                  <Link to="/review" className="btn-primary flex items-center gap-2">
+                    <ClipboardCheck className="w-4 h-4" />
+                    Go to Review Queue
+                  </Link>
+                )
+              }
+            />
           </div>
         )}
       </div>

--- a/web/src/pages/ReviewPage.tsx
+++ b/web/src/pages/ReviewPage.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react'
 import { documents as docApi } from '@/lib/api'
 import type { Document } from '@/lib/api'
-import { CheckCircle2, XCircle, AlertTriangle, RefreshCw, ClipboardCheck } from 'lucide-react'
+import { CheckCircle2, XCircle, AlertTriangle, RefreshCw, ClipboardCheck, Upload, WifiOff } from 'lucide-react'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { Link } from 'react-router-dom'
 
 interface ReviewPageProps {
   onError?: (error: string) => void
@@ -11,16 +12,19 @@ interface ReviewPageProps {
 export function ReviewPage({ onError }: ReviewPageProps) {
   const [queue, setQueue] = useState<Document[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const [action, setAction] = useState<{ id: number; type: 'approve' | 'reject' } | null>(null)
   const [rejectReason, setRejectReason] = useState('')
 
   const loadQueue = async () => {
     setLoading(true)
+    setLoadError(false)
     try {
       const res = await docApi.reviewQueue()
       setQueue(res.items ?? [])
     } catch (err) {
       console.error('Failed to load review queue:', err)
+      setLoadError(true)
     } finally {
       setLoading(false)
     }
@@ -46,11 +50,42 @@ export function ReviewPage({ onError }: ReviewPageProps) {
     }
   }
 
+  if (loadError && !loading) {
+    return (
+      <EmptyState
+        icon={WifiOff}
+        title="Could not load review queue"
+        description="Check your connection and try again."
+        action={
+          <button onClick={loadQueue} className="btn-primary flex items-center gap-2">
+            <RefreshCw className="w-4 h-4" />
+            Retry
+          </button>
+        }
+      />
+    )
+  }
+
   if (loading) {
     return (
-      <div className="flex flex-col items-center justify-center h-64 space-y-3">
-        <div className="w-8 h-8 border-2 border-[var(--primary)]/30 border-t-[var(--primary)] rounded-full animate-spin" />
-        <span className="text-sm text-[var(--muted-foreground)] font-medium">Checking queue...</span>
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <div className="h-6 w-48 rounded bg-[var(--muted)] animate-pulse" />
+          <div className="h-5 w-12 rounded-full bg-[var(--muted)] animate-pulse" />
+        </div>
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="card space-y-3 p-5">
+            <div className="flex items-center gap-3">
+              <div className="h-4 w-40 rounded bg-[var(--muted)] animate-pulse" />
+              <div className="h-5 w-20 rounded-full bg-[var(--muted)] animate-pulse" />
+            </div>
+            <div className="h-3 w-56 rounded bg-[var(--muted)] animate-pulse" />
+            <div className="flex justify-end gap-2">
+              <div className="h-8 w-24 rounded-lg bg-[var(--muted)] animate-pulse" />
+              <div className="h-8 w-24 rounded-lg bg-[var(--muted)] animate-pulse" />
+            </div>
+          </div>
+        ))}
       </div>
     )
   }
@@ -59,8 +94,14 @@ export function ReviewPage({ onError }: ReviewPageProps) {
     return (
       <EmptyState
         icon={CheckCircle2}
-        title="All caught up!"
-        description="No documents are currently pending manual review."
+        title="No documents waiting for review"
+        description="Upload a packing list or invoice to begin."
+        action={
+          <Link to="/documents" className="btn-primary flex items-center gap-2">
+            <Upload className="w-4 h-4" />
+            Upload Document
+          </Link>
+        }
       />
     )
   }


### PR DESCRIPTION
## Summary
- Add contextual empty states with CTAs to all pages
- Add error states with retry buttons to all pages
- Add skeleton table loading states (no spinners)
- New reusable SkeletonTable component

## Test plan
- [x] All existing tests pass (761 passed, 11 skipped)
- [x] TypeScript type-check passes
- [ ] Each page shows appropriate empty state when no data
- [ ] Error states show retry button
- [ ] Loading states show skeleton rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)