### PR TITLE
Prepare lab-manager for external trial and self-serve deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 *.pyd
 .pytest_cache/
 .coverage
+coverage.json
 htmlcov/
 .mypy_cache/
 .ruff_cache/
@@ -14,6 +15,8 @@ htmlcov/
 .idea/
 .vscode/
 *.egg-info/
+build/
+dist/
 
 # OCR benchmark outputs
 ocr-benchmark/data/renders/
@@ -43,6 +46,8 @@ benchmarks/
 ocr-benchmark/data/scans/
 ocr-benchmark/reports/
 .gstack/
+.context/
+uploads/
 
 # Lab-specific data (real audit/extraction outputs)
 docs/audit_log.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to LabClaw Lab Manager will be documented in this file.
 
+## [0.1.5] - 2026-03-19
+
+### Fixed
+- Wheel builds now include the shipped static frontend assets required for the backend-served UI
+
+### Changed
+- Reworked release docs around local trial, one-command deployment, and first-run browser setup
+- Added a local environment bootstrap script for evaluators who want to try Lab Manager on `localhost`
+- Clarified that the React frontend is still an in-progress release surface
+
 ## [0.1.2] - 2026-03-16
 
 ### Added

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -16,25 +16,28 @@ Production deployment guide.
 git clone git@github.com:labclaw/lab-manager.git
 cd lab-manager
 cp .env.example .env
-# Edit .env — fill in ADMIN_SECRET_KEY and API keys
+# Edit .env — fill in secrets and any optional API keys
 
 # 2. Generate a secret key for session signing
 python -c "import secrets; print(secrets.token_hex(32))"
 # Paste the output into ADMIN_SECRET_KEY in .env
 
-# 3. Start services
+# 3. If you are deploying on localhost over plain HTTP, set:
+# SECURE_COOKIES=false
+
+# 4. Start services
 docker compose up -d
 
-# 4. Run database migrations
+# 5. Run database migrations
 docker compose exec app uv run alembic upgrade head
-
-# 5. Create initial admin user
-docker compose exec app uv run python scripts/set_staff_password.py admin@lab.edu YourPassword123
-# (Staff must already exist in the database — imported from document intake)
 
 # 6. Verify
 curl http://localhost:8000/api/health
-# Expected: {"status":"ok","services":{"postgresql":"ok","meilisearch":"ok","gemini":"ok"}}
+# Expected core services: postgresql=ok, meilisearch=ok
+
+# 7. Open the app in a browser and finish setup
+# http://localhost
+# The first-run wizard creates the initial admin account.
 ```
 
 ## Environment Variables
@@ -47,7 +50,7 @@ See `.env.example` for the full list. Critical variables:
 | `MEILISEARCH_URL` | Yes | Meilisearch endpoint |
 | `ADMIN_SECRET_KEY` | Yes | Session cookie signing key (32+ hex chars) |
 | `AUTH_ENABLED` | No | Default `true`. Set `false` for dev only |
-| `SECURE_COOKIES` | No | Set `true` when behind HTTPS |
+| `SECURE_COOKIES` | No | Set `true` behind HTTPS, `false` for localhost HTTP |
 | `GEMINI_API_KEY` | No | Required for AI extraction and RAG |
 | `DATABASE_READONLY_URL` | No | Separate read-only PG user for RAG queries |
 
@@ -93,19 +96,19 @@ gunzip -c /backups/labmanager/labmanager_20260316_020000.sql.gz | \
   psql "$DATABASE_URL"
 ```
 
-## Staff Onboarding
+## First-Run Setup
 
 ```bash
-# Set password for existing staff member
-docker compose exec app uv run python scripts/set_staff_password.py user@lab.edu NewPassword
-
-# Staff members are created via the admin panel at /admin/
-# or imported automatically from document intake (received_by fields)
+# Visit http://localhost and create the first admin account.
+# After the first admin exists, add more staff via /admin/ or import them
+# gradually through document intake data.
 ```
+
+`/admin/` uses the `ADMIN_PASSWORD` from `.env`.
 
 ## Monitoring
 
-- **Health endpoint**: `GET /api/health` — returns service status (PG, Meilisearch, Gemini)
+- **Health endpoint**: `GET /api/health` — returns service status (PG, Meilisearch, LLM config, disk)
 - **Request tracing**: Every response includes `X-Request-ID` header for log correlation
 - **Admin panel**: `/admin/` — SQLAdmin UI for direct database management
 - **Logs**: Structured JSON via structlog with `request_id`, `user`, `timestamp`
@@ -124,6 +127,7 @@ curl -s http://localhost:8000/api/health | python -m json.tool
 |---------|-------|-----|
 | 401 on all requests | `ADMIN_SECRET_KEY` not set | Set in `.env`, restart |
 | Health returns 503 | PostgreSQL or Meilisearch down | `docker compose up -d` |
-| Login fails | No password set for staff | Run `scripts/set_staff_password.py` |
+| Login fails on localhost | `SECURE_COOKIES=true` over HTTP | Set `SECURE_COOKIES=false` and restart |
+| Login fails after first-run setup | No admin was created successfully | Re-open `/` and finish the setup wizard |
 | Empty search results | Meilisearch not indexed | Run `uv run python scripts/index_meilisearch.py` |
 | RAG returns errors | `GEMINI_API_KEY` not set | Add to `.env`, restart |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include src/lab_manager/static/index.html
+include src/lab_manager/static/manifest.json
+include src/lab_manager/static/sw.js
+recursive-include src/lab_manager/static/js *.js
+recursive-include src/lab_manager/static/icons *

--- a/README.md
+++ b/README.md
@@ -1,55 +1,75 @@
-# lab-manager
+# Lab Manager
 
-Lab inventory management system with AI document intake for academic research labs.
+Lab Manager is a lab operations app for research groups that need one place to receive supplies, review scanned documents, track inventory, and keep an audit trail.
 
-## What it does
+Core flow:
 
-1. Staff photographs a packing list, invoice, or shipping label
-2. OCR extracts text from the scan
-3. Three VLMs extract structured data in parallel (vendor, products, quantities, lot numbers, dates)
-4. Consensus merge resolves disagreements; unresolved conflicts go to human review
-5. Approved data flows into the inventory database — searchable, trackable, auditable
+1. A lab member uploads a packing slip, invoice, or shipment image.
+2. OCR and extraction turn the document into structured order data.
+3. Low-confidence fields go to a human review queue.
+4. Approved records land in inventory, orders, analytics, search, and audit logs.
 
-## Stack
+## Release Status
 
-- **Backend:** Python 3.12+, FastAPI, SQLModel, PostgreSQL 17, Alembic
-- **Search:** Meilisearch full-text search with typo tolerance
-- **Frontend:** Vanilla JS SPA with hash routing
-- **AI Pipeline:** Multi-VLM consensus extraction (Claude, Gemini, GPT) + OCR
-- **Infrastructure:** Docker Compose, Caddy reverse proxy, Cloudflare Tunnel
-- **Package manager:** uv
+`v0.1.5` is a private preview release. The backend, database model, setup wizard, login flow, review queue, inventory lifecycle, export, search, and admin surface are in place.
 
-## Quick start
+The React frontend in [`web/`](web/) is an in-progress replacement, not the default release surface. The shipped app currently relies on the backend-served UI under [`src/lab_manager/static/`](src/lab_manager/static/).
+
+## Try It Locally
+
+Fastest path for a scientist or evaluator who just wants to see the product work:
 
 ```bash
-docker compose up -d          # PostgreSQL + Meilisearch
-uv run alembic upgrade head   # Apply migrations
-uv run uvicorn lab_manager.api.app:app --reload  # Dev server on :8000
-uv run pytest                 # Tests
+cd lab-manager
+bash scripts/bootstrap_local_env.sh "My Lab"
+docker compose up -d --build
 ```
 
-## API
+Then open `http://localhost`, finish the browser setup wizard, and sign in.
 
-71 endpoints across vendors, products, orders, inventory, documents, search, analytics, alerts, audit, and export. All list endpoints return paginated responses with filtering and sorting.
+Notes:
+- The generated local `.env` disables secure cookies so login works over plain HTTP on `localhost`.
+- AI keys are optional for a first pass. Without `GEMINI_API_KEY`, the core CRUD, login, admin, search, and inventory flows still work, but AI extraction and RAG features will stay unavailable.
+- `/admin/` uses the generated `ADMIN_PASSWORD` printed by the bootstrap script.
 
-Key workflows:
-- **Document intake:** Upload scan → OCR → VLM extraction → review → approve/reject
-- **Inventory lifecycle:** Receive → consume/transfer/adjust/dispose
-- **Search:** Full-text search via Meilisearch + NL→SQL via Gemini RAG
+## Create Your Own Lab Manager
 
-## Project structure
+For a real lab deployment, use one of these paths:
 
+1. One-command installer: [`deploy/install.sh`](deploy/install.sh)
+2. DigitalOcean droplet bootstrap: [`deploy/README.md`](deploy/README.md)
+3. Manual Docker deployment: [`DEPLOY.md`](DEPLOY.md)
+
+The installer is designed for non-technical users on Ubuntu or Debian. It generates secrets, starts the stack, and leaves the final admin-account creation to the first-run browser wizard.
+
+## Current Surface
+
+- Backend: FastAPI, SQLModel, PostgreSQL 17, Alembic, Meilisearch
+- Default UI: backend-served app under [`src/lab_manager/static/`](src/lab_manager/static/)
+- In-progress replacement UI: React app under [`web/`](web/)
+- Deployment: Docker Compose, Caddy, optional Cloudflare Tunnel
+
+## Developer Quick Start
+
+```bash
+uv sync --dev
+docker compose up -d db search
+uv run alembic upgrade head
+uv run uvicorn lab_manager.api.app:create_app --factory --reload
+uv run pytest
 ```
+
+## Project Layout
+
+```text
 src/lab_manager/
-  api/           — FastAPI app + routes
-  models/        — SQLModel DB models
-  intake/        — Document intake pipeline (OCR, VLM providers, consensus)
-  services/      — Search, RAG, alerts, analytics, audit, inventory
-  config.py      — Settings from env/.env
-scripts/         — CLI tools (pipeline, populate_db, index_meilisearch)
-tests/           — pytest suite
+  api/           FastAPI app, auth, routes, admin, static serving
+  intake/        OCR, extraction providers, validation, consensus
+  models/        SQLModel models
+  services/      Search, analytics, inventory, audit, alerts, RAG
+  static/        Shipped frontend assets and PWA files
+scripts/         Bootstrap, indexing, import, maintenance utilities
+deploy/          Installer and deployment helpers
+tests/           Pytest suite
+web/             Experimental React frontend
 ```
-
-## License
-
-Private — not yet open source.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,6 +1,23 @@
 # Deployment Guide
 
-Three ways to deploy Lab Manager, from easiest to most customizable.
+Three practical ways to get Lab Manager in front of a user, from fastest evaluation to a real deployment.
+
+## Option 0: Local Trial On Your Laptop
+
+Best for product evaluation, demos, and first-time users who want to try the app before adopting it.
+
+```bash
+cd lab-manager
+bash scripts/bootstrap_local_env.sh "My Lab"
+docker compose up -d --build
+```
+
+Then open `http://localhost` and complete the setup wizard in the browser.
+
+This path is intentionally local-friendly:
+- it generates secrets automatically
+- it sets `SECURE_COOKIES=false` for localhost HTTP
+- it does not require an AI API key to explore the core product
 
 ## Option 1: One-Command Install
 
@@ -61,7 +78,7 @@ All three options end the same way:
 
 The SQLAdmin panel is available at `/admin/` using the generated `ADMIN_PASSWORD` (printed by the installer or stored in `/opt/labclaw/.admin_password` on DigitalOcean).
 
-To enable AI features (document extraction, natural language queries), add a Gemini API key to `.env` and restart:
+To enable AI features later, add a Gemini API key to `.env` and restart:
 
 ```bash
 # Edit .env and set GEMINI_API_KEY=your-key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,20 @@ dependencies = [
 requires = ["setuptools>=75.0"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+lab_manager = [
+  "static/index.html",
+  "static/manifest.json",
+  "static/sw.js",
+  "static/js/*.js",
+  "static/icons/*",
+]
 
 [dependency-groups]
 dev = [

--- a/scripts/bootstrap_local_env.sh
+++ b/scripts/bootstrap_local_env.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env"
+
+generate_password() {
+  local length="${1:-32}"
+  tr -dc 'A-Za-z0-9' < /dev/urandom | head -c "$length"
+}
+
+generate_hex() {
+  local length="${1:-64}"
+  tr -dc 'a-f0-9' < /dev/urandom | head -c "$length"
+}
+
+escape_env() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+if [[ -f "$ENV_FILE" ]]; then
+  echo ".env already exists at $ENV_FILE" >&2
+  echo "Move it aside or edit it directly if you want to keep existing settings." >&2
+  exit 1
+fi
+
+LAB_NAME_INPUT="${1:-${LAB_NAME:-My Lab}}"
+LAB_SUBTITLE_INPUT="${LAB_SUBTITLE:-}"
+
+LAB_NAME_ESCAPED="$(escape_env "$LAB_NAME_INPUT")"
+LAB_SUBTITLE_ESCAPED="$(escape_env "$LAB_SUBTITLE_INPUT")"
+
+POSTGRES_PASSWORD="$(generate_password 32)"
+POSTGRES_RO_PASSWORD="$(generate_password 32)"
+MEILI_MASTER_KEY="$(generate_password 32)"
+ADMIN_SECRET_KEY="$(generate_hex 64)"
+ADMIN_PASSWORD="$(generate_password 16)"
+
+cat > "$ENV_FILE" <<EOF
+# Generated for local evaluation on $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+# Safe defaults for trying Lab Manager on http://localhost
+
+DOMAIN=localhost
+
+POSTGRES_USER=labmanager
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+POSTGRES_DB=labmanager
+POSTGRES_RO_PASSWORD=${POSTGRES_RO_PASSWORD}
+
+MEILI_ENV=development
+MEILI_MASTER_KEY=${MEILI_MASTER_KEY}
+
+LAB_NAME="${LAB_NAME_ESCAPED}"
+LAB_SUBTITLE="${LAB_SUBTITLE_ESCAPED}"
+
+ADMIN_SECRET_KEY=${ADMIN_SECRET_KEY}
+ADMIN_PASSWORD=${ADMIN_PASSWORD}
+AUTH_ENABLED=true
+SECURE_COOKIES=false
+
+GEMINI_API_KEY=
+EXTRACTION_MODEL=gemini-3.1-flash-preview
+RAG_MODEL=gemini-2.5-flash
+
+UPLOAD_DIR=uploads
+SCANS_DIR=
+DEVICES_DIR=
+CLOUDFLARED_TOKEN=
+EOF
+
+chmod 600 "$ENV_FILE"
+
+cat <<EOF
+Wrote $ENV_FILE
+
+Next steps:
+  cd $ROOT_DIR
+  docker compose up -d --build
+  visit http://localhost in your browser
+
+First-run flow:
+  1. Finish the setup wizard in the browser
+  2. Sign in with the admin account you just created
+  3. Optional: use ADMIN_PASSWORD=${ADMIN_PASSWORD} for /admin/
+EOF

--- a/web/README.md
+++ b/web/README.md
@@ -1,73 +1,36 @@
-# React + TypeScript + Vite
+# Lab Manager React Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This directory contains the React + TypeScript frontend for Lab Manager.
 
-Currently, two official plugins are available:
+Current status:
+- It is an in-progress replacement for the backend-served UI in [`../src/lab_manager/static/`](../src/lab_manager/static/).
+- FastAPI only serves the React app when build output exists in [`../src/lab_manager/static/dist/`](../src/lab_manager/static/dist/).
+- The browser setup flow documented in the main release notes still assumes the backend-served UI is the canonical surface.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Commands
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+cd web
+bun install
+bun run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Development proxy targets the backend on `http://localhost:8000`.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+To produce a build that FastAPI can serve:
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+cd web
+bun run build
 ```
+
+This writes assets into `../src/lab_manager/static/dist`.
+
+## Release Guidance
+
+Do not treat `web/` as the default shipping surface until feature parity is explicit.
+Before shipping the React app, verify at minimum:
+- first-run setup
+- login and logout
+- dashboard, documents, review, inventory, and orders flows
+- asset serving from `/assets`


### PR DESCRIPTION
## Summary
- tighten the public-facing README and deployment docs around local trial and first-run setup
- add a local bootstrap script so evaluators can bring up Lab Manager on localhost quickly
- include shipped static frontend assets in built distributions and ignore local release noise
- clarify that the React frontend is still an in-progress release surface

## Verification
- uv run pytest tests/test_setup.py -q
- bash -n scripts/bootstrap_local_env.sh
- uv build and confirm the wheel contains static frontend assets
