### PR TITLE
feat(deploy): DO App Platform one-click deploy

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,78 @@
+name: shenlab-manager
+region: nyc
+
+services:
+  - name: app
+    github:
+      repo: labclaw/lab-manager
+      branch: main
+      deploy_on_push: true
+    dockerfile_path: Dockerfile
+    http_port: 8000
+    instance_count: 1
+    instance_size_slug: professional-xs
+    health_check:
+      http_path: /api/health
+      initial_delay_seconds: 30
+      period_seconds: 30
+    envs:
+      - key: DATABASE_URL
+        scope: RUN_TIME
+        value: ${db.DATABASE_URL}
+      - key: MEILISEARCH_URL
+        scope: RUN_TIME
+        value: http://search:7700
+      - key: MEILISEARCH_API_KEY
+        scope: RUN_TIME
+        value: ${MEILI_MASTER_KEY}
+      - key: ADMIN_SECRET_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: MEILI_MASTER_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: LAB_NAME
+        scope: RUN_TIME
+        value: "Shen Lab"
+      - key: LAB_SUBTITLE
+        scope: RUN_TIME
+        value: "Massachusetts General Hospital"
+      - key: AUTH_ENABLED
+        scope: RUN_TIME
+        value: "true"
+      - key: SECURE_COOKIES
+        scope: RUN_TIME
+        value: "true"
+      - key: LOG_FORMAT
+        scope: RUN_TIME
+        value: "json"
+      - key: GEMINI_API_KEY
+        scope: RUN_TIME
+        type: SECRET
+
+  - name: search
+    image:
+      registry_type: DOCKER_HUB
+      repository: getmeili/meilisearch
+      tag: v1.12
+    internal_ports:
+      - 7700
+    instance_count: 1
+    instance_size_slug: professional-xs
+    envs:
+      - key: MEILI_ENV
+        scope: RUN_TIME
+        value: production
+      - key: MEILI_MASTER_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: MEILI_NO_ANALYTICS
+        scope: RUN_TIME
+        value: "true"
+
+databases:
+  - name: db
+    engine: PG
+    version: "16"
+    size: db-s-dev-database
+    num_nodes: 1

--- a/src/lab_manager/config.py
+++ b/src/lab_manager/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+from pydantic import model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -14,6 +15,18 @@ class Settings(BaseSettings):
     database_url: str = (
         "postgresql+psycopg://labmanager:labmanager@localhost:5432/labmanager"
     )
+
+    @model_validator(mode="after")
+    def _normalize_database_urls(self):
+        """Ensure SQLAlchemy dialect prefix for managed DB providers (e.g. DO App Platform)."""
+        for attr in ("database_url", "database_readonly_url"):
+            val = getattr(self, attr)
+            if val and val.startswith("postgresql://"):
+                object.__setattr__(
+                    self, attr, val.replace("postgresql://", "postgresql+psycopg://", 1)
+                )
+        return self
+
     meilisearch_url: str = "http://localhost:7700"
     meilisearch_api_key: str = ""
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,3 +10,19 @@ def test_config_loads_from_env(monkeypatch):
     s = get_settings()
     assert "testdb" in s.database_url
     assert s.meilisearch_url == "http://localhost:7700"
+
+
+def test_database_url_normalization():
+    """DO App Platform provides postgresql:// but SQLAlchemy needs postgresql+psycopg://."""
+    from lab_manager.config import Settings
+
+    s = Settings(database_url="postgresql://user:pass@host:5432/db")
+    assert s.database_url == "postgresql+psycopg://user:pass@host:5432/db"
+
+
+def test_database_url_already_normalized():
+    """URLs with +psycopg should not be double-prefixed."""
+    from lab_manager.config import Settings
+
+    s = Settings(database_url="postgresql+psycopg://user:pass@host:5432/db")
+    assert s.database_url == "postgresql+psycopg://user:pass@host:5432/db"


### PR DESCRIPTION
## Summary
- Add `.do/app.yaml` for DigitalOcean App Platform one-click deploy
- Normalize `postgresql://` URLs from managed DB providers to `postgresql+psycopg://`
- Architecture: FastAPI app + Meilisearch (internal) + managed PostgreSQL
- Configured for Shen Lab (LAB_NAME, LAB_SUBTITLE)

## Test plan
- [x] `doctl apps spec validate .do/app.yaml` passes
- [x] 781 tests pass (2 new config URL normalization tests)
- [x] Existing `postgresql+psycopg://` URLs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)