### PR TITLE
fix(deploy): resolve DO App Platform startup crash

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -13,8 +13,9 @@ services:
     instance_size_slug: professional-xs
     health_check:
       http_path: /api/health
-      initial_delay_seconds: 30
+      initial_delay_seconds: 60
       period_seconds: 30
+      timeout_seconds: 10
     envs:
       - key: DATABASE_URL
         scope: RUN_TIME
@@ -53,7 +54,8 @@ services:
   - name: search
     image:
       registry_type: DOCKER_HUB
-      repository: getmeili/meilisearch
+      registry: getmeili
+      repository: meilisearch
       tag: v1.12
     internal_ports:
       - 7700

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,22 @@
 #!/bin/sh
 set -e
 
+# Wait for PostgreSQL to accept connections before running migrations.
+# Managed databases (e.g. DO App Platform) may need extra time to provision.
+echo "[entrypoint] Waiting for database..."
+MAX_RETRIES=30
+RETRY=0
+until pg_isready -d "$DATABASE_URL" -q 2>/dev/null; do
+    RETRY=$((RETRY + 1))
+    if [ "$RETRY" -ge "$MAX_RETRIES" ]; then
+        echo "[entrypoint] ERROR: database not ready after ${MAX_RETRIES} attempts"
+        exit 1
+    fi
+    echo "[entrypoint] Database not ready (attempt $RETRY/$MAX_RETRIES), waiting 2s..."
+    sleep 2
+done
+echo "[entrypoint] Database is ready."
+
 echo "[entrypoint] Running database migrations..."
 uv run alembic upgrade head
 

--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -277,9 +277,10 @@ def create_app() -> FastAPI:
             logger.error("Health check: disk check failed: %s", e)
             checks["disk"] = "error"
 
-        # Only core services (postgresql, meilisearch) can degrade health.
-        # LLM and disk are informational — don't take service out of rotation.
-        core = {k: v for k, v in checks.items() if k in ("postgresql", "meilisearch")}
+        # Only PostgreSQL is truly core — without it the app can't serve any data.
+        # Meilisearch is important but starts independently (especially on managed
+        # platforms like DO App Platform) and shouldn't take the app out of rotation.
+        core = {k: v for k, v in checks.items() if k in ("postgresql",)}
         all_ok = all(v == "ok" for v in core.values())
         return JSONResponse(
             {"status": "ok" if all_ok else "degraded", "services": checks},

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -289,7 +289,12 @@ class TestAppHealthEndpoints:
     """Exercise the health endpoint service checks."""
 
     def test_health_with_meilisearch_error(self, client):
-        """Health check when Meilisearch is unavailable."""
+        """Health check still returns 200 when Meilisearch is unavailable.
+
+        Meilisearch is not core — the app can serve data without search.
+        This is critical for managed deployments (e.g. DO App Platform)
+        where search starts independently.
+        """
         with patch("lab_manager.services.search.get_search_client") as mock_get_client:
             mock_client = MagicMock()
             mock_client.health.side_effect = Exception("connection refused")
@@ -297,7 +302,8 @@ class TestAppHealthEndpoints:
 
             resp = client.get("/api/health")
             data = resp.json()
-            assert "services" in data
+            assert resp.status_code == 200
+            assert data["services"]["meilisearch"] == "error"
 
     def test_health_with_disk_error(self, client):
         """Health check when disk usage check fails."""


### PR DESCRIPTION
## Summary
- **Wait for DB**: entrypoint now runs `pg_isready` loop (up to 60s) before `alembic upgrade head` — fixes `DeployContainerExitNonZero` when managed PG isn't ready
- **Non-core Meilisearch**: health check returns 200 even when search is down (reported as "degraded") — fixes `DeployContainerTerminated` caused by 503 health checks
- **Docker Hub image format**: split `getmeili/meilisearch` into `registry: getmeili` + `repository: meilisearch` per DO spec
- **Health check timing**: `initial_delay_seconds` 30→60, added `timeout_seconds: 10`

## Test plan
- [x] `doctl apps spec validate .do/app.yaml` passes
- [x] Health check tests pass (Meilisearch down → 200, PG down → 503)
- [ ] Deploy to DO App Platform and verify app starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)