### PR TITLE
fix(deploy): grant schema CREATE before Alembic migrations

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -20,22 +20,6 @@ services:
       - key: DATABASE_URL
         scope: RUN_TIME
         value: ${db.DATABASE_URL}
-      # Direct DB connection components for migrations (bypass connection pool)
-      - key: DB_HOST
-        scope: RUN_TIME
-        value: ${db.HOSTNAME}
-      - key: DB_PORT
-        scope: RUN_TIME
-        value: ${db.PORT}
-      - key: DB_USER
-        scope: RUN_TIME
-        value: ${db.USERNAME}
-      - key: DB_PASSWORD
-        scope: RUN_TIME
-        value: ${db.PASSWORD}
-      - key: DB_NAME
-        scope: RUN_TIME
-        value: ${db.DATABASE}
       - key: MEILISEARCH_URL
         scope: RUN_TIME
         value: http://search:7700

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,23 +1,12 @@
 #!/bin/sh
 set -e
 
-# Build a direct database URL for migrations if DO App Platform individual
-# DB env vars are available. The ${db.DATABASE_URL} often routes through
-# PgBouncer whose pool user lacks CREATE permission on the public schema.
-if [ -n "$DB_HOST" ] && [ -n "$DB_PORT" ] && [ -n "$DB_USER" ] && [ -n "$DB_PASSWORD" ] && [ -n "$DB_NAME" ]; then
-    MIGRATION_URL="postgresql+psycopg://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}?sslmode=require"
-    echo "[entrypoint] Using direct DB connection for migrations (bypassing pool)."
-else
-    MIGRATION_URL="$DATABASE_URL"
-    echo "[entrypoint] Using DATABASE_URL for migrations."
-fi
-
 # Wait for PostgreSQL to accept connections before running migrations.
 # Managed databases (e.g. DO App Platform) may need extra time to provision.
 echo "[entrypoint] Waiting for database..."
 MAX_RETRIES=30
 RETRY=0
-until pg_isready -d "$MIGRATION_URL" -q 2>/dev/null; do
+until pg_isready -d "$DATABASE_URL" -q 2>/dev/null; do
     RETRY=$((RETRY + 1))
     if [ "$RETRY" -ge "$MAX_RETRIES" ]; then
         echo "[entrypoint] ERROR: database not ready after ${MAX_RETRIES} attempts"
@@ -28,8 +17,15 @@ until pg_isready -d "$MIGRATION_URL" -q 2>/dev/null; do
 done
 echo "[entrypoint] Database is ready."
 
+# On managed PG (e.g. DO App Platform), the connection pool user may lack
+# CREATE permission on the public schema (PG 15+ default). Try to grant it
+# before running Alembic. Failure is non-fatal (permission may already exist
+# or the connected user may be the schema owner).
+echo "[entrypoint] Ensuring schema permissions..."
+psql "$DATABASE_URL" -c "GRANT CREATE ON SCHEMA public TO CURRENT_USER;" 2>/dev/null || true
+
 echo "[entrypoint] Running database migrations..."
-DATABASE_URL="$MIGRATION_URL" uv run alembic upgrade head
+uv run alembic upgrade head
 
 echo "[entrypoint] Starting application..."
 exec uv run uvicorn lab_manager.api.app:create_app --factory --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- Use `psql GRANT CREATE ON SCHEMA public TO CURRENT_USER` before Alembic runs (non-fatal fallback)
- Removes unused direct DB component env vars (direct connection is inaccessible from App Platform)
- Follows up on #72 (wait loop + non-core Meilisearch) and #74 (service sizing)

Addresses PG 16 default `REVOKE CREATE ON SCHEMA public FROM PUBLIC` which blocks Alembic's `CREATE TABLE alembic_version`.

## Test plan
- [ ] Deploy to DO App Platform — GRANT should enable migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)