### PR TITLE
fix(deploy): use custom schema for DO managed PG

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,7 +1,7 @@
 """Alembic migration environment."""
 
 from alembic import context
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlmodel import SQLModel
 
 # Import all models so they register with SQLModel.metadata
@@ -10,12 +10,26 @@ from lab_manager.config import get_settings
 
 target_metadata = SQLModel.metadata
 
+# Schema used for all tables. On managed platforms (e.g. DO App Platform)
+# the default user may lack CREATE privilege on the 'public' schema.
+# Using a custom schema the app user owns avoids this PG 15+ restriction.
+APP_SCHEMA = "labmanager"
+
 
 def run_migrations_online():
     settings = get_settings()
     engine = create_engine(settings.database_url)
     with engine.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        # Ensure our custom schema exists and is in the search path.
+        connection.execute(text(f"CREATE SCHEMA IF NOT EXISTS {APP_SCHEMA}"))
+        connection.execute(text(f"SET search_path TO {APP_SCHEMA}, public"))
+        connection.commit()
+
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table_schema=APP_SCHEMA,
+        )
         with context.begin_transaction():
             context.run_migrations()
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,22 +16,6 @@ until pg_isready -d "$DATABASE_URL" -q 2>/dev/null; do
 done
 echo "[entrypoint] Database is ready."
 
-# Debug: show connected user and schema permissions
-echo "[entrypoint] Checking database permissions..."
-psql "$DATABASE_URL" -c "SELECT current_user, session_user, current_database(), current_schema();" 2>&1 || true
-psql "$DATABASE_URL" -c "SELECT nspname, nspowner, pg_catalog.pg_get_userbyid(nspowner) AS owner FROM pg_namespace WHERE nspname = 'public';" 2>&1 || true
-psql "$DATABASE_URL" -c "SELECT has_schema_privilege(current_user, 'public', 'CREATE') AS can_create;" 2>&1 || true
-
-# On managed PG (e.g. DO App Platform), the connection pool user may lack
-# CREATE permission on the public schema (PG 15+ default). Try multiple
-# approaches to fix this.
-echo "[entrypoint] Ensuring schema permissions..."
-psql "$DATABASE_URL" -c "GRANT ALL ON SCHEMA public TO CURRENT_USER;" 2>&1 || true
-psql "$DATABASE_URL" -c "ALTER SCHEMA public OWNER TO CURRENT_USER;" 2>&1 || true
-
-# Verify the fix worked
-psql "$DATABASE_URL" -c "SELECT has_schema_privilege(current_user, 'public', 'CREATE') AS can_create_after_fix;" 2>&1 || true
-
 echo "[entrypoint] Running database migrations..."
 uv run alembic upgrade head
 

--- a/src/lab_manager/database.py
+++ b/src/lab_manager/database.py
@@ -28,7 +28,16 @@ def get_engine():
                     pass
                 else:
                     kwargs.update(pool_size=10, max_overflow=20, pool_pre_ping=True)
+                # On managed PG (e.g. DO App Platform) the app user may lack
+                # CREATE on the 'public' schema. Use a custom schema to avoid
+                # this PG 15+ restriction. Set search_path via connect_args.
+                if not settings.database_url.startswith("sqlite"):
+                    kwargs.setdefault("connect_args", {})
+                    kwargs["connect_args"]["options"] = (
+                        "-c search_path=labmanager,public"
+                    )
                 _engine = create_engine(settings.database_url, **kwargs)
+
     return _engine
 
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -40,6 +40,7 @@ class TestGetEngine:
             pool_size=10,
             max_overflow=20,
             pool_pre_ping=True,
+            connect_args={"options": "-c search_path=labmanager,public"},
         )
         assert engine is mock_create.return_value
 


### PR DESCRIPTION
## Summary
DO App Platform connects as user `db` which lacks CREATE on `public` schema (PG 16 default). The user can't GRANT or ALTER SCHEMA.

Fix: use a custom `labmanager` schema that the app user owns:
- Alembic creates schema before running migrations
- All connections set `search_path=labmanager,public` via `connect_args`
- Clean entrypoint (removed debug/GRANT attempts)

## Test plan
- [x] 14 database + health tests pass
- [ ] Deploy to DO App Platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)