### PR TITLE
feat(web): light mode default + remove Shen Lab branding

### DIFF
--- a/src/lab_manager/static/dist/index.html
+++ b/src/lab_manager/static/dist/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LabClaw Lab Manager</title>
-    <script type="module" crossorigin src="/assets/index-p9AbZRwz.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DsLgO3Ro.css">
+    <script type="module" crossorigin src="/assets/index-DpxyozJ-.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D7LRXwuB.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,10 +27,10 @@ const PAGE_TITLES: Record<string, string> = {
 function AlertsPage() {
   return (
     <div className="text-center py-16 space-y-3">
-      <h3 className="text-lg font-display font-semibold text-slate-100">
+      <h3 className="text-lg font-display font-semibold text-[var(--foreground)]">
         Alerts
       </h3>
-      <p className="text-sm text-slate-500">
+      <p className="text-sm text-[var(--muted-foreground)]">
         Alerts page
       </p>
     </div>
@@ -40,10 +40,10 @@ function AlertsPage() {
 function SettingsPage() {
   return (
     <div className="text-center py-16 space-y-3">
-      <h3 className="text-lg font-display font-semibold text-slate-100">
+      <h3 className="text-lg font-display font-semibold text-[var(--foreground)]">
         Settings
       </h3>
-      <p className="text-sm text-slate-500">
+      <p className="text-sm text-[var(--muted-foreground)]">
         Settings page coming soon
       </p>
     </div>
@@ -81,9 +81,14 @@ export default function App() {
   }, [])
 
   useEffect(() => {
-    // Stitch designs are dark-only — always enable dark mode
-    setDarkMode(true)
-    document.documentElement.classList.add('dark')
+    const stored = localStorage.getItem('darkMode')
+    const isDark = stored === 'true'
+    setDarkMode(isDark)
+    if (isDark) {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
   }, [])
 
   const toggleDarkMode = () => {
@@ -118,7 +123,7 @@ export default function App() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-screen bg-background-dark">
+      <div className="flex items-center justify-center h-screen bg-[var(--background)]">
         <div className="w-8 h-8 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
       </div>
     )
@@ -135,7 +140,7 @@ export default function App() {
   return (
     <>
       <ErrorBanner error={error} onDismiss={() => setError(null)} />
-      <div className="flex h-screen bg-background-dark overflow-hidden">
+      <div className="flex h-screen bg-[var(--background)] overflow-hidden">
         <Sidebar
           current={location.pathname}
           collapsed={sidebarCollapsed}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -11,15 +11,15 @@ export function Header({ title: _title, onSearch, darkMode, onToggleDarkMode }: 
   const [searchQuery, setSearchQuery] = useState('')
 
   return (
-    <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-primary/10 px-6 py-4 lg:px-10 bg-background-dark/80 backdrop-blur-md sticky top-0 z-50">
+    <header className="flex items-center justify-between whitespace-nowrap border-b border-solid border-primary/10 px-6 py-4 lg:px-10 bg-[var(--background)]/80 backdrop-blur-md sticky top-0 z-50">
       <div className="flex items-center gap-8 flex-1">
         <label className="hidden md:flex flex-col max-w-xl w-full h-10">
           <div className="flex w-full flex-1 items-stretch rounded-lg h-full">
-            <div className="text-slate-400 flex border-none bg-card-dark items-center justify-center pl-4 rounded-l-lg">
+            <div className="text-[var(--muted-foreground)] flex border-none bg-[var(--card)] items-center justify-center pl-4 rounded-l-lg">
               <span className="material-symbols-outlined text-xl">search</span>
             </div>
             <input
-              className="form-input flex w-full min-w-0 flex-1 border-none bg-card-dark text-slate-100 focus:ring-1 focus:ring-primary/50 h-full placeholder:text-slate-500 px-4 rounded-r-lg text-sm font-normal"
+              className="form-input flex w-full min-w-0 flex-1 border-none bg-[var(--card)] text-[var(--foreground)] focus:ring-1 focus:ring-primary/50 h-full placeholder:text-[var(--muted-foreground)] px-4 rounded-r-lg text-sm font-normal"
               placeholder="Search products, vendors, orders..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
@@ -31,20 +31,20 @@ export function Header({ title: _title, onSearch, darkMode, onToggleDarkMode }: 
         </label>
       </div>
       <div className="flex items-center gap-4">
-        <button className="flex items-center justify-center rounded-lg size-10 bg-card-dark text-slate-100 hover:bg-primary/20 transition-colors">
+        <button className="flex items-center justify-center rounded-lg size-10 bg-[var(--card)] text-[var(--foreground)] hover:bg-primary/20 transition-colors">
           <span className="material-symbols-outlined text-xl">notifications</span>
         </button>
         <button
           onClick={onToggleDarkMode}
           aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-          className="flex items-center justify-center rounded-lg size-10 bg-card-dark text-slate-100 hover:bg-primary/20 transition-colors"
+          className="flex items-center justify-center rounded-lg size-10 bg-[var(--card)] text-[var(--foreground)] hover:bg-primary/20 transition-colors"
         >
           <span className="material-symbols-outlined text-xl">
             {darkMode ? 'light_mode' : 'dark_mode'}
           </span>
         </button>
         <div className="flex items-center gap-3 pl-4 border-l border-primary/10">
-          <span className="text-sm font-medium text-slate-400">Dr. Aris Thorne</span>
+          <span className="text-sm font-medium text-[var(--muted-foreground)]">Admin</span>
         </div>
       </div>
     </header>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -34,7 +34,7 @@ export function Sidebar({
   return (
     <aside
       className={cn(
-        'hidden md:flex flex-col bg-sidebar-dark border-r border-primary/10 transition-all duration-300',
+        'hidden md:flex flex-col bg-[var(--sidebar)] border-r border-primary/10 transition-all duration-300',
         collapsed ? 'w-16' : 'w-64',
       )}
     >
@@ -45,8 +45,8 @@ export function Sidebar({
         </div>
         {!collapsed && (
           <div>
-            <h2 className="text-slate-100 text-xl font-bold leading-none tracking-tight">Lab Manager</h2>
-            <p className="text-[10px] text-slate-500 font-bold uppercase tracking-widest mt-1">MGH Neuroscience</p>
+            <h2 className="text-[var(--foreground)] text-xl font-bold leading-none tracking-tight">Lab Manager</h2>
+            <p className="text-[10px] text-[var(--muted-foreground)] font-bold uppercase tracking-widest mt-1">Laboratory</p>
           </div>
         )}
       </div>
@@ -69,7 +69,7 @@ export function Sidebar({
                 'flex items-center gap-3 px-4 py-2.5 rounded-lg transition-colors',
                 isActive
                   ? 'bg-primary/10 text-primary font-semibold'
-                  : 'text-slate-400 hover:bg-primary/5 hover:text-slate-100',
+                  : 'text-[var(--muted-foreground)] hover:bg-primary/5 hover:text-[var(--foreground)]',
               )}
               title={collapsed ? item.label : undefined}
             >
@@ -95,13 +95,13 @@ export function Sidebar({
           </div>
           {!collapsed && (
             <div className="overflow-hidden">
-              <p className="text-sm font-bold text-slate-100 truncate">Dr. Aris Thorne</p>
+              <p className="text-sm font-bold text-[var(--foreground)] truncate">Admin</p>
             </div>
           )}
         </div>
         <button
           onClick={handleLogout}
-          className="flex items-center gap-3 w-full px-4 py-2 text-slate-400 hover:text-red-400 transition-colors text-sm font-medium"
+          className="flex items-center gap-3 w-full px-4 py-2 text-[var(--muted-foreground)] hover:text-red-400 transition-colors text-sm font-medium"
           title={collapsed ? 'Sign Out' : undefined}
         >
           <span className="material-symbols-outlined text-lg">logout</span>
@@ -113,7 +113,7 @@ export function Sidebar({
       <button
         onClick={onToggle}
         aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        className="hidden lg:flex absolute -right-3 top-20 items-center justify-center w-6 h-6 rounded-full bg-card-dark border border-primary/10 text-slate-400 hover:text-slate-100 transition-colors"
+        className="hidden lg:flex absolute -right-3 top-20 items-center justify-center w-6 h-6 rounded-full bg-[var(--card)] border border-primary/10 text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
       >
         <span className="material-symbols-outlined text-sm">
           {collapsed ? 'chevron_right' : 'chevron_left'}

--- a/web/src/components/ui/SkeletonTable.tsx
+++ b/web/src/components/ui/SkeletonTable.tsx
@@ -5,17 +5,17 @@ interface SkeletonTableProps {
 
 export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
   return (
-    <div className="bg-card-dark border border-border-dark rounded-xl overflow-hidden">
+    <div className="bg-[var(--card)] border border-[var(--border)] rounded-xl overflow-hidden">
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-border-dark">
+          <tr className="border-b border-[var(--border)]">
             {Array.from({ length: columns }).map((_, i) => (
               <th
                 key={i}
-                className="text-left px-4 py-3 text-xs font-medium text-slate-500 uppercase tracking-wider"
+                className="text-left px-4 py-3 text-xs font-medium text-[var(--muted-foreground)] uppercase tracking-wider"
               >
                 <div
-                  className="h-3 w-16 rounded bg-slate-800 animate-pulse"
+                  className="h-3 w-16 rounded bg-[var(--border)] animate-pulse"
                   style={{ animationDelay: `${i * 75}ms` }}
                 />
               </th>
@@ -24,11 +24,11 @@ export function SkeletonTable({ rows = 5, columns = 4 }: SkeletonTableProps) {
         </thead>
         <tbody>
           {Array.from({ length: rows }).map((_, rowIdx) => (
-            <tr key={rowIdx} className="border-b border-border-dark last:border-0">
+            <tr key={rowIdx} className="border-b border-[var(--border)] last:border-0">
               {Array.from({ length: columns }).map((_, colIdx) => (
                 <td key={colIdx} className="px-4 py-3">
                   <div
-                    className="h-4 rounded bg-slate-800 animate-pulse"
+                    className="h-4 rounded bg-[var(--border)] animate-pulse"
                     style={{
                       width: `${50 + ((rowIdx * columns + colIdx) * 17) % 40}%`,
                       animationDelay: `${(rowIdx * columns + colIdx) * 75}ms`,

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -109,7 +109,7 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
     <div className="space-y-8">
       {/* Quick Actions Row */}
       <div className="mb-8">
-        <h3 className="text-slate-400 text-[10px] font-bold uppercase tracking-widest mb-4">Quick Actions</h3>
+        <h3 className="text-[var(--muted-foreground)] text-[10px] font-bold uppercase tracking-widest mb-4">Quick Actions</h3>
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
           <button
             onClick={() => navigate('/upload')}
@@ -120,21 +120,21 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
           </button>
           <button
             onClick={() => navigate('/orders')}
-            className="flex items-center justify-center gap-3 p-4 bg-card-dark border border-primary/20 hover:border-primary/50 text-slate-100 rounded-xl font-bold text-sm transition-all group"
+            className="flex items-center justify-center gap-3 p-4 bg-[var(--card)] border border-primary/20 hover:border-primary/50 text-[var(--foreground)] rounded-xl font-bold text-sm transition-all group"
           >
             <span className="material-symbols-outlined text-primary group-hover:scale-110 transition-transform">add_shopping_cart</span>
             <span>New Order</span>
           </button>
           <button
             onClick={() => navigate('/inventory')}
-            className="flex items-center justify-center gap-3 p-4 bg-card-dark border border-primary/20 hover:border-primary/50 text-slate-100 rounded-xl font-bold text-sm transition-all group"
+            className="flex items-center justify-center gap-3 p-4 bg-[var(--card)] border border-primary/20 hover:border-primary/50 text-[var(--foreground)] rounded-xl font-bold text-sm transition-all group"
           >
             <span className="material-symbols-outlined text-primary group-hover:scale-110 transition-transform">inventory</span>
             <span>Update Stock</span>
           </button>
           <button
             onClick={() => navigate('/settings')}
-            className="flex items-center justify-center gap-3 p-4 bg-card-dark border border-primary/20 hover:border-primary/50 text-slate-100 rounded-xl font-bold text-sm transition-all group"
+            className="flex items-center justify-center gap-3 p-4 bg-[var(--card)] border border-primary/20 hover:border-primary/50 text-[var(--foreground)] rounded-xl font-bold text-sm transition-all group"
           >
             <span className="material-symbols-outlined text-primary group-hover:scale-110 transition-transform">group</span>
             <span>Manage Lab</span>
@@ -145,55 +145,55 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
       {/* Stats Row */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
         {/* Total Documents */}
-        <div className="bg-card-dark border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-          <div className="flex items-center justify-between text-slate-400 mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Total Documents</span>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--muted-foreground)]">Total Documents</span>
             <span className="material-symbols-outlined text-lg opacity-50">description</span>
           </div>
-          <div className="text-3xl font-bold text-white tracking-tight">{totalDocs}</div>
-          <div className="text-[11px] text-slate-500 font-medium">Total lab docs processed</div>
+          <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{totalDocs}</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">Total lab docs processed</div>
         </div>
 
         {/* Approved - green left border */}
-        <div className="bg-card-dark border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm border-l-4 border-l-accent-green">
-          <div className="flex items-center justify-between text-slate-400 mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Approved</span>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm border-l-4 border-l-accent-green">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--muted-foreground)]">Approved</span>
             <span className="material-symbols-outlined text-lg text-accent-green">check_circle</span>
           </div>
           <div className="text-3xl font-bold text-accent-green tracking-tight">{approved}</div>
-          <div className="text-[11px] text-slate-500 font-medium">{approvalPct}% automation accuracy</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">{approvalPct}% automation accuracy</div>
         </div>
 
         {/* Needs Review - amber left border */}
-        <div className="bg-card-dark border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm border-l-4 border-l-amber-400">
-          <div className="flex items-center justify-between text-slate-400 mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Needs Review</span>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm border-l-4 border-l-amber-400">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--muted-foreground)]">Needs Review</span>
             <span className="material-symbols-outlined text-lg text-amber-400">pending_actions</span>
           </div>
           <div className="text-3xl font-bold text-amber-400 tracking-tight">{needsReview}</div>
-          <div className="text-[11px] text-slate-500 font-medium">Awaiting lab verification</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">Awaiting lab verification</div>
         </div>
 
         {/* Orders Created */}
-        <div className="bg-card-dark border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-          <div className="flex items-center justify-between text-slate-400 mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Orders Created</span>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--muted-foreground)]">Orders Created</span>
             <span className="material-symbols-outlined text-lg opacity-50">shopping_bag</span>
           </div>
-          <div className="text-3xl font-bold text-white tracking-tight">{ordersCreated}</div>
-          <div className="text-[11px] text-slate-500 font-medium">
+          <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{ordersCreated}</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">
             {stats?.total_inventory_items ?? 0} line items reconciled
           </div>
         </div>
 
         {/* Vendors */}
-        <div className="bg-card-dark border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-          <div className="flex items-center justify-between text-slate-400 mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider text-slate-400">Vendors</span>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider text-[var(--muted-foreground)]">Vendors</span>
             <span className="material-symbols-outlined text-lg opacity-50">storefront</span>
           </div>
-          <div className="text-3xl font-bold text-white tracking-tight">{totalVendors}</div>
-          <div className="text-[11px] text-slate-500 font-medium">Discovered from scan history</div>
+          <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{totalVendors}</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">Discovered from scan history</div>
         </div>
       </div>
 
@@ -212,7 +212,7 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
           </div>
           <button
             onClick={() => navigate('/inventory')}
-            className="px-4 py-2 bg-amber-400 text-background-dark rounded-lg text-xs font-bold uppercase tracking-wider hover:bg-amber-300 transition-colors shadow-lg shadow-amber-400/10"
+            className="px-4 py-2 bg-amber-400 text-[var(--background)] rounded-lg text-xs font-bold uppercase tracking-wider hover:bg-amber-300 transition-colors shadow-lg shadow-amber-400/10"
           >
             Reorder Now
           </button>
@@ -241,13 +241,13 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
       {/* Charts Section */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         {/* Top Lab Vendors */}
-        <div className="bg-card-dark border border-primary/10 rounded-xl p-6 shadow-sm">
+        <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
           <div className="flex items-center justify-between mb-8">
-            <h3 className="text-slate-100 text-lg font-bold flex items-center gap-2">
+            <h3 className="text-[var(--foreground)] text-lg font-bold flex items-center gap-2">
               <span className="material-symbols-outlined text-primary">analytics</span>
               Top Lab Vendors
             </h3>
-            <span className="text-[10px] font-bold text-slate-500 uppercase tracking-widest bg-slate-800 px-2 py-1 rounded">
+            <span className="text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-widest bg-[var(--card)] px-2 py-1 rounded">
               Last 90 Days
             </span>
           </div>
@@ -257,18 +257,18 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
                 <div key={v.name} className="space-y-2 group">
                   <div className="flex justify-between items-end">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-slate-200 font-semibold">{v.name}</span>
+                      <span className="text-sm text-[var(--foreground)] font-semibold">{v.name}</span>
                       {i === 0 && (
                         <span className="hidden group-hover:block text-[10px] bg-primary/20 text-primary px-1.5 py-0.5 rounded font-bold">
                           Primary Vendor
                         </span>
                       )}
                     </div>
-                    <span className="text-xs text-slate-400 font-mono">
+                    <span className="text-xs text-[var(--muted-foreground)] font-mono">
                       {v.count} orders ({v.pct}%)
                     </span>
                   </div>
-                  <div className="h-2.5 w-full bg-slate-800 rounded-full overflow-hidden">
+                  <div className="h-2.5 w-full bg-[var(--card)] rounded-full overflow-hidden">
                     <div
                       className={VENDOR_BAR_CLASSES[i] ?? VENDOR_BAR_CLASSES[4]}
                       style={{ width: `${v.width}%` }}
@@ -277,15 +277,15 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
                 </div>
               ))
             ) : (
-              <div className="text-sm text-slate-500 py-4">No vendor data yet</div>
+              <div className="text-sm text-[var(--muted-foreground)] py-4">No vendor data yet</div>
             )}
           </div>
         </div>
 
         {/* Document Classification */}
-        <div className="bg-card-dark border border-primary/10 rounded-xl p-6 shadow-sm">
+        <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
           <div className="flex items-center justify-between mb-8">
-            <h3 className="text-slate-100 text-lg font-bold flex items-center gap-2">
+            <h3 className="text-[var(--foreground)] text-lg font-bold flex items-center gap-2">
               <span className="material-symbols-outlined text-primary">folder_open</span>
               Document Classification
             </h3>
@@ -302,16 +302,16 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
                 <div key={d.type} className="space-y-2 group">
                   <div className="flex justify-between items-end">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-slate-200 font-mono">{d.type}</span>
+                      <span className="text-sm text-[var(--foreground)] font-mono">{d.type}</span>
                       {i === 0 && totalDocs > 0 && (
                         <span className="hidden group-hover:block text-[10px] bg-accent-green/20 text-accent-green px-1.5 py-0.5 rounded font-bold">
                           {Math.round((d.count / totalDocs) * 100)}% of docs
                         </span>
                       )}
                     </div>
-                    <span className="text-xs text-slate-400 font-mono">{d.count} files</span>
+                    <span className="text-xs text-[var(--muted-foreground)] font-mono">{d.count} files</span>
                   </div>
-                  <div className="h-2.5 w-full bg-slate-800 rounded-full overflow-hidden">
+                  <div className="h-2.5 w-full bg-[var(--card)] rounded-full overflow-hidden">
                     <div
                       className={DOC_BAR_CLASSES[i] ?? DOC_BAR_CLASSES[3]}
                       style={{ width: `${d.width}%` }}
@@ -320,7 +320,7 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
                 </div>
               ))
             ) : (
-              <div className="text-sm text-slate-500 py-4">No document data yet</div>
+              <div className="text-sm text-[var(--muted-foreground)] py-4">No document data yet</div>
             )}
           </div>
         </div>

--- a/web/src/pages/InventoryPage.tsx
+++ b/web/src/pages/InventoryPage.tsx
@@ -85,16 +85,16 @@ export function InventoryPage({ onError }: InventoryPageProps) {
       {/* Filters & Actions Bar */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
-          <button className="flex items-center gap-2 px-4 py-2 bg-card-dark rounded-xl shadow-sm hover:bg-surface-container-high transition-colors text-sm font-medium border border-outline">
+          <button className="flex items-center gap-2 px-4 py-2 bg-[var(--card)] rounded-xl shadow-sm hover:bg-surface-container-high transition-colors text-sm font-medium border border-outline">
             <span className="material-symbols-outlined text-lg">filter_list</span>
             <span>Filters</span>
           </button>
-          <button className="flex items-center gap-2 px-4 py-2 bg-card-dark rounded-xl shadow-sm hover:bg-surface-container-high transition-colors text-sm font-medium border border-outline">
+          <button className="flex items-center gap-2 px-4 py-2 bg-[var(--card)] rounded-xl shadow-sm hover:bg-surface-container-high transition-colors text-sm font-medium border border-outline">
             <span className="material-symbols-outlined text-lg">category</span>
             <span>Category</span>
           </button>
-          <div className="h-6 w-px bg-[#2d2d44] mx-2" />
-          <span className="text-xs text-slate-400 font-medium">
+          <div className="h-6 w-px bg-[var(--border)] mx-2" />
+          <span className="text-xs text-[var(--muted-foreground)] font-medium">
             {total.toLocaleString()} Items total
           </span>
         </div>
@@ -111,17 +111,17 @@ export function InventoryPage({ onError }: InventoryPageProps) {
       </div>
 
       {/* Inventory Data Table */}
-      <section className="bg-card-dark rounded-[2rem] shadow-sm overflow-hidden flex flex-col flex-1 border border-outline">
+      <section className="bg-[var(--card)] rounded-[2rem] shadow-sm overflow-hidden flex flex-col flex-1 border border-outline">
         <div className="overflow-x-auto">
           <table className="w-full text-left border-collapse">
             <thead>
               <tr className="bg-surface-container-high/50">
-                <th className="px-8 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider">Item Name</th>
-                <th className="px-6 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider">Lot #</th>
-                <th className="px-6 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider">Vendor</th>
-                <th className="px-6 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider">Location</th>
-                <th className="px-6 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider">Stock</th>
-                <th className="px-6 py-5 text-xs font-bold text-slate-400 uppercase tracking-wider text-right">Actions</th>
+                <th className="px-8 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Item Name</th>
+                <th className="px-6 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Lot #</th>
+                <th className="px-6 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Vendor</th>
+                <th className="px-6 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Location</th>
+                <th className="px-6 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Stock</th>
+                <th className="px-6 py-5 text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider text-right">Actions</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-outline">
@@ -134,13 +134,13 @@ export function InventoryPage({ onError }: InventoryPageProps) {
                         <p className="font-bold text-on-surface">
                           {item.product_name ?? `Product #${item.product_id}`}
                         </p>
-                        <p className="text-[11px] text-slate-400">
+                        <p className="text-[11px] text-[var(--muted-foreground)]">
                           {item.lot_number ? `Lot ${item.lot_number}` : (item.unit ?? '')}
                         </p>
                       </div>
                     </div>
                   </td>
-                  <td className="px-6 py-6 text-sm font-mono text-slate-400">
+                  <td className="px-6 py-6 text-sm font-mono text-[var(--muted-foreground)]">
                     {item.lot_number ?? '\u2014'}
                   </td>
                   <td className="px-6 py-6 text-sm font-medium">
@@ -148,12 +148,12 @@ export function InventoryPage({ onError }: InventoryPageProps) {
                   </td>
                   <td className="px-6 py-6">
                     {item.location_name ? (
-                      <span className="inline-flex items-center px-2.5 py-1 rounded-lg bg-surface-container-high text-slate-400 text-xs font-medium border border-outline">
+                      <span className="inline-flex items-center px-2.5 py-1 rounded-lg bg-surface-container-high text-[var(--muted-foreground)] text-xs font-medium border border-outline">
                         <span className="material-symbols-outlined text-[14px] mr-1">meeting_room</span>
                         {item.location_name}
                       </span>
                     ) : (
-                      <span className="text-slate-400">{'\u2014'}</span>
+                      <span className="text-[var(--muted-foreground)]">{'\u2014'}</span>
                     )}
                   </td>
                   <td className="px-6 py-6">
@@ -169,7 +169,7 @@ export function InventoryPage({ onError }: InventoryPageProps) {
                       <button className="p-2 hover:bg-primary/20 text-primary rounded-lg transition-colors" title="Order More">
                         <span className="material-symbols-outlined">shopping_cart_checkout</span>
                       </button>
-                      <button className="p-2 hover:bg-surface-container-highest text-slate-400 rounded-lg transition-colors" title="Edit Item">
+                      <button className="p-2 hover:bg-surface-container-highest text-[var(--muted-foreground)] rounded-lg transition-colors" title="Edit Item">
                         <span className="material-symbols-outlined">edit</span>
                       </button>
                     </div>
@@ -182,11 +182,11 @@ export function InventoryPage({ onError }: InventoryPageProps) {
           {items.length === 0 && (
             <div className="flex flex-col items-center justify-center py-16 text-center space-y-4">
               <div className="w-12 h-12 rounded-2xl bg-surface-container-high flex items-center justify-center">
-                <span className="material-symbols-outlined text-slate-400">inventory_2</span>
+                <span className="material-symbols-outlined text-[var(--muted-foreground)]">inventory_2</span>
               </div>
               <div className="space-y-1">
                 <h3 className="text-base font-semibold text-on-surface">Inventory is empty</h3>
-                <p className="text-sm text-slate-400 max-w-xs mx-auto">
+                <p className="text-sm text-[var(--muted-foreground)] max-w-xs mx-auto">
                   Process documents through the review queue to populate inventory.
                 </p>
               </div>
@@ -197,7 +197,7 @@ export function InventoryPage({ onError }: InventoryPageProps) {
         {/* Pagination Footer */}
         {total > 0 && (
           <div className="mt-auto px-8 py-4 bg-surface-container-lowest/30 border-t border-outline flex items-center justify-between">
-            <span className="text-xs text-slate-400 font-medium">
+            <span className="text-xs text-[var(--muted-foreground)] font-medium">
               Showing {startItem}-{endItem} of {total.toLocaleString()} items
             </span>
             <div className="flex items-center gap-2">
@@ -239,7 +239,7 @@ export function InventoryPage({ onError }: InventoryPageProps) {
 
       {/* Bottom Stats Bento Cards — matches Stitch design */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
-        <div className="p-6 bg-card-dark rounded-3xl border border-outline shadow-sm flex flex-col justify-between">
+        <div className="p-6 bg-[var(--card)] rounded-3xl border border-outline shadow-sm flex flex-col justify-between">
           <div>
             <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Storage Status</span>
             <h3 className="text-2xl font-bold mt-1">{total > 0 ? '94%' : '0%'}</h3>
@@ -252,7 +252,7 @@ export function InventoryPage({ onError }: InventoryPageProps) {
             {total > 0 ? 'Freezer #4 nearing capacity' : 'No items stored'}
           </p>
         </div>
-        <div className="p-6 bg-card-dark rounded-3xl border border-outline shadow-sm">
+        <div className="p-6 bg-[var(--card)] rounded-3xl border border-outline shadow-sm">
           <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Monthly Spend</span>
           <h3 className="text-2xl font-bold mt-1 text-on-surface">
             ${total > 0 ? '4,120' : '0'}
@@ -262,15 +262,15 @@ export function InventoryPage({ onError }: InventoryPageProps) {
             <span className="text-xs font-bold">{total > 0 ? '+12% vs last month' : 'No spending data'}</span>
           </div>
         </div>
-        <div className="p-6 bg-card-dark rounded-3xl border border-outline shadow-sm">
+        <div className="p-6 bg-[var(--card)] rounded-3xl border border-outline shadow-sm">
           <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Active Orders</span>
           <h3 className="text-2xl font-bold mt-1 text-on-surface">0</h3>
           <div className="mt-4 flex -space-x-2">
-            <div className="w-7 h-7 rounded-full bg-primary border-2 border-card-dark flex items-center justify-center text-[10px] text-white font-bold">V</div>
-            <div className="w-7 h-7 rounded-full bg-[#2d2d44] border-2 border-card-dark flex items-center justify-center text-[10px] text-slate-400 font-bold">S</div>
+            <div className="w-7 h-7 rounded-full bg-primary border-2 border-[var(--card)] flex items-center justify-center text-[10px] text-white font-bold">V</div>
+            <div className="w-7 h-7 rounded-full bg-[var(--border)] border-2 border-[var(--card)] flex items-center justify-center text-[10px] text-[var(--muted-foreground)] font-bold">S</div>
           </div>
         </div>
-        <div className="p-6 bg-card-dark rounded-3xl border border-outline shadow-sm">
+        <div className="p-6 bg-[var(--card)] rounded-3xl border border-outline shadow-sm">
           <span className="text-[10px] font-bold text-on-surface-variant uppercase tracking-widest">Audit Due</span>
           <h3 className="text-2xl font-bold mt-1 text-on-surface">14 Days</h3>
           <button className="mt-4 text-xs font-bold text-primary flex items-center gap-1 hover:underline">

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -22,18 +22,18 @@ export function LoginPage() {
   }
 
   return (
-    <div className="bg-background-dark font-[Inter,sans-serif] text-slate-100 flex items-center justify-center min-h-screen p-4">
+    <div className="bg-[var(--background)] font-[Inter,sans-serif] text-[var(--foreground)] flex items-center justify-center min-h-screen p-4">
       {/* Login Card Container */}
-      <div className="w-full max-w-96 bg-card-dark border border-[#2d2d44] rounded-xl p-8 shadow-2xl">
+      <div className="w-full max-w-96 bg-[var(--card)] border border-[var(--border)] rounded-xl p-8 shadow-2xl">
         {/* Header / Logo Section */}
         <div className="flex flex-col items-center gap-2 mb-8">
           <div className="flex items-center gap-2">
             <div className="bg-primary/20 p-2 rounded-lg flex items-center justify-center">
               <span className="material-symbols-outlined text-primary text-3xl">science</span>
             </div>
-            <h1 className="text-white text-2xl font-bold tracking-tight">LabClaw</h1>
+            <h1 className="text-[var(--foreground)] text-2xl font-bold tracking-tight">LabClaw</h1>
           </div>
-          <p className="text-[#8E8EA0] text-sm font-medium">Lab Manager</p>
+          <p className="text-[var(--muted-foreground)] text-sm font-medium">Lab Manager</p>
         </div>
 
         {/* Error message */}
@@ -47,15 +47,15 @@ export function LoginPage() {
         <form onSubmit={handleSubmit} className="flex flex-col gap-5">
           {/* Email Input */}
           <div className="flex flex-col gap-2">
-            <label htmlFor="email" className="text-slate-300 text-sm font-medium ml-1">Email</label>
+            <label htmlFor="email" className="text-[var(--foreground)] text-sm font-medium ml-1">Email</label>
             <div className="relative">
-              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[#8E8EA0] text-xl">mail</span>
+              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] text-xl">mail</span>
               <input
                 id="email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full pl-11 pr-4 py-3 bg-background-dark border border-[#2d2d44] rounded-lg text-white placeholder:text-[#8E8EA0] focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all outline-none"
+                className="w-full pl-11 pr-4 py-3 bg-[var(--background)] border border-[var(--border)] rounded-lg text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all outline-none"
                 placeholder="Enter your email"
                 required
                 autoFocus
@@ -66,17 +66,17 @@ export function LoginPage() {
           {/* Password Input */}
           <div className="flex flex-col gap-2">
             <div className="flex justify-between items-center px-1">
-              <label htmlFor="password" className="text-slate-300 text-sm font-medium">Password</label>
+              <label htmlFor="password" className="text-[var(--foreground)] text-sm font-medium">Password</label>
               <a href="#" className="text-primary text-xs font-semibold hover:underline">Forgot password?</a>
             </div>
             <div className="relative">
-              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[#8E8EA0] text-xl">lock</span>
+              <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] text-xl">lock</span>
               <input
                 id="password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full pl-11 pr-4 py-3 bg-background-dark border border-[#2d2d44] rounded-lg text-white placeholder:text-[#8E8EA0] focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all outline-none"
+                className="w-full pl-11 pr-4 py-3 bg-[var(--background)] border border-[var(--border)] rounded-lg text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:ring-2 focus:ring-primary/50 focus:border-primary transition-all outline-none"
                 placeholder="Enter your password"
                 required
               />
@@ -88,9 +88,9 @@ export function LoginPage() {
             <input
               id="remember"
               type="checkbox"
-              className="w-4 h-4 rounded border-[#2d2d44] bg-background-dark text-primary focus:ring-offset-background-dark"
+              className="w-4 h-4 rounded border-[var(--border)] bg-[var(--background)] text-primary focus:ring-offset-[var(--background)]"
             />
-            <label htmlFor="remember" className="text-[#8E8EA0] text-sm">Remember this device</label>
+            <label htmlFor="remember" className="text-[var(--muted-foreground)] text-sm">Remember this device</label>
           </div>
 
           {/* Sign In Button */}
@@ -115,7 +115,7 @@ export function LoginPage() {
 
         {/* Footer Info */}
         <div className="mt-8 text-center">
-          <p className="text-[#8E8EA0] text-sm">
+          <p className="text-[var(--muted-foreground)] text-sm">
             Don&apos;t have an account?{' '}
             <a href="#" className="text-primary font-semibold hover:underline">Request access</a>
           </p>
@@ -123,7 +123,7 @@ export function LoginPage() {
       </div>
 
       {/* Security Badge */}
-      <div className="fixed bottom-6 flex items-center gap-2 text-[#8E8EA0]/50">
+      <div className="fixed bottom-6 flex items-center gap-2 text-[var(--muted-foreground)]/50">
         <span className="material-symbols-outlined text-sm">verified_user</span>
         <span className="text-[10px] uppercase tracking-widest font-bold">Secure Environment</span>
       </div>

--- a/web/src/pages/OrdersPage.tsx
+++ b/web/src/pages/OrdersPage.tsx
@@ -178,7 +178,7 @@ export function OrdersPage({ onError }: OrdersPageProps) {
                         <div className={`w-8 h-8 rounded-full flex items-center justify-center z-10 shadow-md ${
                           active || current
                             ? 'bg-primary text-white'
-                            : 'bg-surface-container text-slate-500/40 border border-outline'
+                            : 'bg-surface-container text-[var(--muted-foreground)]/40 border border-outline'
                         }`}>
                           <span className="material-symbols-outlined text-sm"
                             style={active ? { fontVariationSettings: "'FILL' 1" } : undefined}
@@ -234,7 +234,7 @@ export function OrdersPage({ onError }: OrdersPageProps) {
                 <div className="space-y-4">
                   {isPending ? (
                     <div className="p-3 bg-surface-container-low rounded-lg text-[11px] text-on-surface-variant italic">
-                      Awaiting sign-off from Lab Manager head (Principal Investigator)
+                      Awaiting sign-off from lab administrator
                     </div>
                   ) : (
                     <div className="flex justify-between items-end">
@@ -292,10 +292,10 @@ export function OrdersPage({ onError }: OrdersPageProps) {
                 </p>
               </div>
               <div className="flex -space-x-2 mt-4 overflow-hidden">
-                <div className="h-6 w-6 rounded-full border-2 border-[#2a2a44] bg-slate-700" />
-                <div className="h-6 w-6 rounded-full border-2 border-[#2a2a44] bg-slate-600" />
-                <div className="h-6 w-6 rounded-full border-2 border-[#2a2a44] bg-slate-500" />
-                <div className="h-6 w-6 rounded-full border-2 border-[#2a2a44] bg-primary flex items-center justify-center text-[8px] font-bold text-white">+39</div>
+                <div className="h-6 w-6 rounded-full border-2 border-[var(--border)] bg-[var(--muted-foreground)]" />
+                <div className="h-6 w-6 rounded-full border-2 border-[var(--border)] bg-[var(--muted-foreground)]" />
+                <div className="h-6 w-6 rounded-full border-2 border-[var(--border)] bg-[var(--muted-foreground)]" />
+                <div className="h-6 w-6 rounded-full border-2 border-[var(--border)] bg-primary flex items-center justify-center text-[8px] font-bold text-white">+39</div>
               </div>
             </div>
           </div>

--- a/web/src/pages/ReviewPage.tsx
+++ b/web/src/pages/ReviewPage.tsx
@@ -105,7 +105,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
     return (
       <div className="flex flex-col items-center justify-center h-64 space-y-3">
         <div className="w-8 h-8 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <span className="text-sm text-slate-500 font-medium">Checking queue...</span>
+        <span className="text-sm text-[var(--muted-foreground)] font-medium">Checking queue...</span>
       </div>
     )
   }
@@ -113,15 +113,15 @@ export function ReviewPage({ onError }: ReviewPageProps) {
   if (queue.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-64 space-y-4">
-        <div className="w-12 h-12 rounded-2xl bg-slate-800 flex items-center justify-center">
-          <span className="material-symbols-outlined text-2xl text-slate-400">
+        <div className="w-12 h-12 rounded-2xl bg-[var(--card)] flex items-center justify-center">
+          <span className="material-symbols-outlined text-2xl text-[var(--muted-foreground)]">
             check_circle
           </span>
         </div>
-        <h3 className="text-base font-semibold text-white">
+        <h3 className="text-base font-semibold text-[var(--foreground)]">
           No documents waiting for review
         </h3>
-        <p className="text-sm text-slate-500">
+        <p className="text-sm text-[var(--muted-foreground)]">
           Upload a packing list or invoice to begin.
         </p>
         <button
@@ -141,25 +141,25 @@ export function ReviewPage({ onError }: ReviewPageProps) {
   return (
     <div className="-m-6 flex flex-col h-[calc(100vh-4rem)]">
       {/* Top Bar */}
-      <header className="h-16 border-b border-border-dark flex items-center justify-between px-6 bg-background-dark shrink-0">
+      <header className="h-16 border-b border-[var(--border)] flex items-center justify-between px-6 bg-[var(--background)] shrink-0">
         <div>
-          <h2 className="text-xl font-bold text-white leading-tight">Review Queue</h2>
-          <p className="text-xs text-slate-500 font-medium">
+          <h2 className="text-xl font-bold text-[var(--foreground)] leading-tight">Review Queue</h2>
+          <p className="text-xs text-[var(--muted-foreground)] font-medium">
             {queue.length} document{queue.length !== 1 ? 's' : ''} awaiting verification
           </p>
         </div>
         <div className="flex items-center gap-4">
           <div className="relative">
-            <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 text-lg">
+            <span className="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] text-lg">
               search
             </span>
             <input
-              className="bg-surface-dark border-border-dark text-sm rounded-lg pl-10 pr-4 py-1.5 w-64 focus:ring-primary focus:border-primary"
+              className="bg-[var(--card)] border-[var(--border)] text-sm rounded-lg pl-10 pr-4 py-1.5 w-64 focus:ring-primary focus:border-primary"
               placeholder="Search filename..."
               type="text"
             />
           </div>
-          <button className="p-2 text-slate-400 hover:text-white">
+          <button className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
             <span className="material-symbols-outlined">filter_list</span>
           </button>
         </div>
@@ -168,7 +168,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
       {/* Workspace Split */}
       <div className="flex-1 flex overflow-hidden min-h-0">
         {/* Document List (40%) */}
-        <section className="w-[40%] border-r border-border-dark flex flex-col bg-surface-dark/30">
+        <section className="w-[40%] border-r border-[var(--border)] flex flex-col bg-[var(--card)]/30">
           <div className="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-3">
             {queue.map((item) => {
               const isSelected = item.id === doc.id
@@ -184,13 +184,13 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                   className={
                     isSelected
                       ? 'p-4 rounded-xl border-2 border-primary bg-primary/5 cursor-pointer relative group'
-                      : 'p-4 rounded-xl border border-border-dark bg-surface-dark/50 hover:bg-surface-dark cursor-pointer transition-all'
+                      : 'p-4 rounded-xl border border-[var(--border)] bg-[var(--card)]/50 hover:bg-[var(--card)] cursor-pointer transition-all'
                   }
                 >
                   <div className="flex justify-between items-start mb-2">
                     <h3
                       className={`text-sm font-bold truncate w-4/5 ${
-                        isSelected ? 'text-white' : 'text-slate-200'
+                        isSelected ? 'text-[var(--foreground)]' : 'text-[var(--foreground)]'
                       }`}
                     >
                       {item.filename ?? `Doc #${item.id}`}
@@ -201,10 +201,10 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                   </div>
                   <div className="flex justify-between items-end">
                     <div className="space-y-0.5">
-                      <p className="text-xs text-slate-400 font-medium">
+                      <p className="text-xs text-[var(--muted-foreground)] font-medium">
                         {item.vendor_name ?? 'Unknown vendor'}
                       </p>
-                      <p className="text-[10px] text-slate-500 italic">
+                      <p className="text-[10px] text-[var(--muted-foreground)] italic">
                         Extracted: {formatDate(item.created_at)}
                       </p>
                     </div>
@@ -221,15 +221,15 @@ export function ReviewPage({ onError }: ReviewPageProps) {
         </section>
 
         {/* Detail Panel (60%) */}
-        <section className="flex-1 flex flex-col bg-background-dark overflow-hidden relative">
+        <section className="flex-1 flex flex-col bg-[var(--background)] overflow-hidden relative">
           {/* Document Preview Area */}
-          <div className="h-[35%] min-h-[300px] p-6 bg-black flex flex-col border-b border-border-dark/50">
+          <div className="h-[35%] min-h-[300px] p-6 bg-black flex flex-col border-b border-[var(--border)]/50">
             <div className="flex items-center justify-between mb-4">
               <div className="flex items-center gap-3">
-                <span className="text-[10px] font-bold text-slate-400 uppercase tracking-widest">
+                <span className="text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-widest">
                   Document Preview
                 </span>
-                <div className="h-4 w-px bg-slate-700" />
+                <div className="h-4 w-px bg-[var(--border)]" />
                 {docDetail.confidence != null && (
                   <span
                     className={`text-xs flex items-center gap-1 font-semibold ${
@@ -252,18 +252,18 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 )}
               </div>
               <div className="flex gap-2">
-                <button className="p-1.5 rounded bg-surface-dark hover:bg-slate-700 text-slate-400">
+                <button className="p-1.5 rounded bg-[var(--card)] hover:bg-[var(--border)] text-[var(--muted-foreground)]">
                   <span className="material-symbols-outlined text-sm">zoom_in</span>
                 </button>
-                <button className="p-1.5 rounded bg-surface-dark hover:bg-slate-700 text-slate-400">
+                <button className="p-1.5 rounded bg-[var(--card)] hover:bg-[var(--border)] text-[var(--muted-foreground)]">
                   <span className="material-symbols-outlined text-sm">zoom_out</span>
                 </button>
-                <button className="p-1.5 rounded bg-surface-dark hover:bg-slate-700 text-slate-400">
+                <button className="p-1.5 rounded bg-[var(--card)] hover:bg-[var(--border)] text-[var(--muted-foreground)]">
                   <span className="material-symbols-outlined text-sm">open_in_new</span>
                 </button>
               </div>
             </div>
-            <div className="flex-1 rounded-lg border border-slate-800 bg-surface-dark/20 flex items-center justify-center overflow-hidden relative group">
+            <div className="flex-1 rounded-lg border border-slate-800 bg-[var(--card)]/20 flex items-center justify-center overflow-hidden relative group">
               <div className="text-center transition-transform group-hover:scale-105 duration-500">
                 <div className="mb-4 bg-primary/20 p-8 inline-block rounded-full relative">
                   <span className="material-symbols-outlined text-primary text-5xl">
@@ -271,10 +271,10 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                   </span>
                   <div className="absolute inset-0 bg-gradient-to-tr from-primary/30 to-transparent animate-pulse rounded-full" />
                 </div>
-                <p className="text-sm text-slate-300 font-medium">
+                <p className="text-sm text-[var(--foreground)] font-medium">
                   {docDetail.filename ?? `Document #${docDetail.id}`}
                 </p>
-                <p className="text-[10px] text-slate-500">Page 1 of 1 &bull; 1.2 MB</p>
+                <p className="text-[10px] text-[var(--muted-foreground)]">Page 1 of 1 &bull; 1.2 MB</p>
               </div>
               {/* Grid pattern for technical feel */}
               <div
@@ -294,18 +294,18 @@ export function ReviewPage({ onError }: ReviewPageProps) {
             <div className="flex-1 p-6 pb-28">
               {/* Extracted Data Grid */}
               <div className="mb-8">
-                <h4 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-4 flex items-center gap-2">
+                <h4 className="text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-widest mb-4 flex items-center gap-2">
                   <span className="material-symbols-outlined text-sm">grid_view</span>
                   Extracted Header Data
                 </h4>
                 <div className="grid grid-cols-2 lg:grid-cols-3 gap-x-6 gap-y-5">
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       Vendor
                     </label>
                     <div className="relative group">
                       <input
-                        className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                        className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                         type="text"
                         readOnly
                         value={docDetail.vendor_name ?? ''}
@@ -316,12 +316,12 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     </div>
                   </div>
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       PO Number
                     </label>
                     <div className="relative">
                       <input
-                        className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                        className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                         type="text"
                         readOnly
                         value="--"
@@ -332,13 +332,13 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     </div>
                   </div>
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       Document Type
                     </label>
                     <select
                       disabled
                       value={docDetail.document_type ?? ''}
-                      className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                      className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                     >
                       <option value="packing_list">Packing List</option>
                       <option value="invoice">Invoice</option>
@@ -349,39 +349,39 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     </select>
                   </div>
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       Ship Date
                     </label>
                     <input
-                      className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                      className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                       type="date"
                       readOnly
                       value=""
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       Received Date
                     </label>
                     <input
-                      className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                      className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 px-3 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                       type="date"
                       readOnly
                       value={docDetail.created_at?.split('T')[0] ?? ''}
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <label className="block text-[10px] font-bold text-slate-500 uppercase tracking-wide">
+                    <label className="block text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wide">
                       Received By
                     </label>
                     <div className="relative">
                       <input
-                        className="w-full bg-surface-dark border-border-dark rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-surface-dark/80"
+                        className="w-full bg-[var(--card)] border-[var(--border)] rounded-lg py-2.5 pl-3 pr-10 text-sm focus:ring-primary focus:border-primary transition-all hover:bg-[var(--card)]/80"
                         placeholder="Scanning name..."
                         type="text"
                         readOnly
                       />
-                      <span className="material-symbols-outlined absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 text-lg">
+                      <span className="material-symbols-outlined absolute right-3 top-1/2 -translate-y-1/2 text-[var(--muted-foreground)] text-lg">
                         edit
                       </span>
                     </div>
@@ -391,14 +391,14 @@ export function ReviewPage({ onError }: ReviewPageProps) {
 
               {/* Line Items Table */}
               <div>
-                <h4 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-4 flex items-center gap-2">
+                <h4 className="text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-widest mb-4 flex items-center gap-2">
                   <span className="material-symbols-outlined text-sm">list_alt</span>
                   Extracted Line Items
                 </h4>
-                <div className="overflow-hidden rounded-xl border border-border-dark bg-surface-dark/30">
+                <div className="overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--card)]/30">
                   <table className="w-full text-left text-sm border-collapse">
                     <thead>
-                      <tr className="bg-surface-dark/60 text-slate-400 font-bold border-b border-border-dark">
+                      <tr className="bg-[var(--card)]/60 text-[var(--muted-foreground)] font-bold border-b border-[var(--border)]">
                         <th className="px-4 py-3 text-[10px] uppercase tracking-wider">
                           Catalog #
                         </th>
@@ -416,10 +416,10 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                         </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-border-dark text-slate-300">
+                    <tbody className="divide-y divide-border-dark text-[var(--foreground)]">
                       <tr className="hover:bg-primary/5 transition-colors">
                         <td
-                          className="px-4 py-3 font-mono text-xs text-slate-300"
+                          className="px-4 py-3 font-mono text-xs text-[var(--foreground)]"
                           colSpan={5}
                         >
                           <span className="italic">
@@ -442,8 +442,8 @@ export function ReviewPage({ onError }: ReviewPageProps) {
             </div>
 
             {/* Side Snippet: Activity Log */}
-            <div className="w-64 border-l border-border-dark/30 p-4 bg-surface-dark/10">
-              <h4 className="text-[10px] font-bold text-slate-500 uppercase tracking-widest mb-4 flex items-center gap-2">
+            <div className="w-64 border-l border-[var(--border)]/30 p-4 bg-[var(--card)]/10">
+              <h4 className="text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-widest mb-4 flex items-center gap-2">
                 <span className="material-symbols-outlined text-sm">history</span>
                 Activity Log
               </h4>
@@ -451,10 +451,10 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 <div className="flex gap-3">
                   <div className="w-1.5 h-1.5 rounded-full bg-emerald-500 mt-1.5 shrink-0" />
                   <div>
-                    <p className="text-[11px] text-slate-200 leading-tight">
+                    <p className="text-[11px] text-[var(--foreground)] leading-tight">
                       Document ingested via Scanner A
                     </p>
-                    <p className="text-[10px] text-slate-500 mt-0.5">
+                    <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
                       {formatDate(docDetail.created_at)}
                     </p>
                   </div>
@@ -462,21 +462,21 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 <div className="flex gap-3">
                   <div className="w-1.5 h-1.5 rounded-full bg-primary mt-1.5 shrink-0" />
                   <div>
-                    <p className="text-[11px] text-slate-200 leading-tight">
+                    <p className="text-[11px] text-[var(--foreground)] leading-tight">
                       AI Extraction completed
                     </p>
-                    <p className="text-[10px] text-slate-500 mt-0.5">
+                    <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
                       {formatDate(docDetail.created_at)}
                     </p>
                   </div>
                 </div>
                 <div className="flex gap-3">
-                  <div className="w-1.5 h-1.5 rounded-full bg-slate-600 mt-1.5 shrink-0" />
+                  <div className="w-1.5 h-1.5 rounded-full bg-[var(--muted-foreground)] mt-1.5 shrink-0" />
                   <div>
-                    <p className="text-[11px] text-slate-400 leading-tight">
+                    <p className="text-[11px] text-[var(--muted-foreground)] leading-tight">
                       Assigned to reviewer
                     </p>
-                    <p className="text-[10px] text-slate-500 mt-0.5">
+                    <p className="text-[10px] text-[var(--muted-foreground)] mt-0.5">
                       {formatDate(docDetail.created_at)}
                     </p>
                   </div>
@@ -486,7 +486,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 <p className="text-[10px] font-bold text-primary uppercase mb-2">
                   Review Tip
                 </p>
-                <p className="text-[11px] text-slate-400 leading-relaxed">
+                <p className="text-[11px] text-[var(--muted-foreground)] leading-relaxed">
                   Check extracted fields against the original document. Flag any
                   mismatches for correction.
                 </p>
@@ -497,17 +497,17 @@ export function ReviewPage({ onError }: ReviewPageProps) {
           {/* Rejection dialog */}
           {rejecting && (
             <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-20">
-              <div className="bg-surface-dark border border-border-dark rounded-xl p-6 w-full max-w-md space-y-4 shadow-2xl">
-                <h3 className="text-base font-semibold text-white">Reject Document</h3>
-                <p className="text-sm text-slate-400">
+              <div className="bg-[var(--card)] border border-[var(--border)] rounded-xl p-6 w-full max-w-md space-y-4 shadow-2xl">
+                <h3 className="text-base font-semibold text-[var(--foreground)]">Reject Document</h3>
+                <p className="text-sm text-[var(--muted-foreground)]">
                   Provide a reason for rejecting{' '}
-                  <span className="font-medium text-white">{doc.filename}</span>
+                  <span className="font-medium text-[var(--foreground)]">{doc.filename}</span>
                 </p>
                 <textarea
                   value={rejectReason}
                   onChange={(e) => setRejectReason(e.target.value)}
                   placeholder="Describe the issue..."
-                  className="w-full h-24 bg-background-dark border border-border-dark rounded-lg px-3 py-2 text-sm text-slate-200 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-primary resize-none"
+                  className="w-full h-24 bg-[var(--background)] border border-[var(--border)] rounded-lg px-3 py-2 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-2 focus:ring-primary resize-none"
                 />
                 <div className="flex items-center gap-3 justify-end">
                   <button
@@ -515,7 +515,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                       setRejecting(false)
                       setRejectReason('')
                     }}
-                    className="px-4 py-2 rounded-lg text-sm font-medium text-slate-400 hover:text-white transition-colors"
+                    className="px-4 py-2 rounded-lg text-sm font-medium text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
                   >
                     Cancel
                   </button>
@@ -537,7 +537,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
           )}
 
           {/* Footer Action Bar */}
-          <footer className="p-4 border-t border-border-dark bg-background-dark/95 backdrop-blur-md absolute bottom-0 left-0 right-0 z-10 shadow-2xl">
+          <footer className="p-4 border-t border-[var(--border)] bg-[var(--background)]/95 backdrop-blur-md absolute bottom-0 left-0 right-0 z-10 shadow-2xl">
             <div className="flex items-center justify-between">
               <div className="flex gap-4">
                 <div className="relative group">
@@ -551,29 +551,29 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     </span>
                     {approveMutation.isPending ? 'Approving...' : 'Approve'}
                   </button>
-                  <span className="absolute -top-1.5 -right-1.5 px-1.5 py-0.5 bg-background-dark border border-border-dark rounded text-[9px] font-bold text-slate-500 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <span className="absolute -top-1.5 -right-1.5 px-1.5 py-0.5 bg-[var(--background)] border border-[var(--border)] rounded text-[9px] font-bold text-[var(--muted-foreground)] opacity-0 group-hover:opacity-100 transition-opacity">
                     &#8984;&#8629;
                   </span>
                 </div>
                 <div className="relative group">
                   <button
                     disabled={actionLoading}
-                    className="px-6 py-2.5 bg-surface-dark border border-primary/40 hover:border-primary text-slate-200 font-bold rounded-lg text-sm transition-all flex items-center gap-2 hover:bg-primary/5 disabled:opacity-50"
+                    className="px-6 py-2.5 bg-[var(--card)] border border-primary/40 hover:border-primary text-[var(--foreground)] font-bold rounded-lg text-sm transition-all flex items-center gap-2 hover:bg-primary/5 disabled:opacity-50"
                   >
                     <span className="material-symbols-outlined text-lg text-primary">
                       edit_document
                     </span>
                     Edit &amp; Approve
                   </button>
-                  <span className="absolute -top-1.5 -right-1.5 px-1.5 py-0.5 bg-background-dark border border-border-dark rounded text-[9px] font-bold text-slate-500 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <span className="absolute -top-1.5 -right-1.5 px-1.5 py-0.5 bg-[var(--background)] border border-[var(--border)] rounded text-[9px] font-bold text-[var(--muted-foreground)] opacity-0 group-hover:opacity-100 transition-opacity">
                     &#8984;E
                   </span>
                 </div>
               </div>
               <div className="flex items-center gap-6">
-                <div className="hidden xl:flex items-center gap-4 text-slate-500 mr-4">
+                <div className="hidden xl:flex items-center gap-4 text-[var(--muted-foreground)] mr-4">
                   <div className="flex items-center gap-1.5">
-                    <kbd className="px-1.5 py-0.5 bg-surface-dark border border-border-dark rounded text-[10px] font-bold">
+                    <kbd className="px-1.5 py-0.5 bg-[var(--card)] border border-[var(--border)] rounded text-[10px] font-bold">
                       ESC
                     </kbd>
                     <span className="text-[10px] font-medium uppercase tracking-wider">
@@ -581,10 +581,10 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     </span>
                   </div>
                   <div className="flex items-center gap-1.5">
-                    <kbd className="px-1.5 py-0.5 bg-surface-dark border border-border-dark rounded text-[10px] font-bold">
+                    <kbd className="px-1.5 py-0.5 bg-[var(--card)] border border-[var(--border)] rounded text-[10px] font-bold">
                       J
                     </kbd>
-                    <kbd className="px-1.5 py-0.5 bg-surface-dark border border-border-dark rounded text-[10px] font-bold">
+                    <kbd className="px-1.5 py-0.5 bg-[var(--card)] border border-[var(--border)] rounded text-[10px] font-bold">
                       K
                     </kbd>
                     <span className="text-[10px] font-medium uppercase tracking-wider">
@@ -595,7 +595,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                 <button
                   onClick={() => setRejecting(true)}
                   disabled={actionLoading}
-                  className="px-6 py-2.5 border-2 border-red-500/30 text-red-400 hover:text-white hover:bg-red-500/80 hover:border-red-500 font-bold rounded-lg text-sm transition-all flex items-center gap-2 disabled:opacity-50"
+                  className="px-6 py-2.5 border-2 border-red-500/30 text-red-400 hover:text-[var(--foreground)] hover:bg-red-500/80 hover:border-red-500 font-bold rounded-lg text-sm transition-all flex items-center gap-2 disabled:opacity-50"
                 >
                   <span className="material-symbols-outlined text-lg">block</span>
                   Reject

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -122,7 +122,7 @@ export function UploadPage() {
         )
       case 'uploading':
         return (
-          <span className="text-xs font-bold text-[#8E8EA0]">{record.progress}%</span>
+          <span className="text-xs font-bold text-[var(--muted-foreground)]">{record.progress}%</span>
         )
       case 'failed':
         return (
@@ -153,8 +153,8 @@ export function UploadPage() {
         onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
         onDragLeave={() => setDragOver(false)}
         onDrop={handleDrop}
-        className={`bg-card-dark rounded-xl border-2 border-dashed p-12 text-center flex flex-col items-center justify-center transition-all group cursor-pointer ${
-          dragOver ? 'border-primary bg-primary/5' : 'border-[#2A2A3E] hover:border-primary/50'
+        className={`bg-[var(--card)] rounded-xl border-2 border-dashed p-12 text-center flex flex-col items-center justify-center transition-all group cursor-pointer ${
+          dragOver ? 'border-primary bg-primary/5' : 'border-[var(--border)] hover:border-primary/50'
         }`}
         onClick={() => fileRef.current?.click()}
       >
@@ -162,7 +162,7 @@ export function UploadPage() {
           <span className="material-symbols-outlined text-primary text-5xl">cloud_upload</span>
         </div>
         <h3 className="text-2xl font-bold mb-2">Drag & drop files here</h3>
-        <p className="text-[#8E8EA0] text-sm mb-8">PDF, PNG, JPG, HEIC -- Max 10MB per file</p>
+        <p className="text-[var(--muted-foreground)] text-sm mb-8">PDF, PNG, JPG, HEIC -- Max 10MB per file</p>
         <div className="flex items-center gap-4">
           <button
             onClick={(e) => { e.stopPropagation(); fileRef.current?.click() }}
@@ -171,10 +171,10 @@ export function UploadPage() {
             <span className="material-symbols-outlined text-xl">upload_file</span>
             Browse Files
           </button>
-          <span className="text-[#8E8EA0] text-sm font-medium">or</span>
+          <span className="text-[var(--muted-foreground)] text-sm font-medium">or</span>
           <button
             onClick={(e) => { e.stopPropagation(); cameraRef.current?.click() }}
-            className="bg-transparent border border-[#2A2A3E] hover:border-primary text-[#F0F0F5] font-bold py-2.5 px-6 rounded-lg transition-all flex items-center gap-2"
+            className="bg-transparent border border-[var(--border)] hover:border-primary text-[var(--foreground)] font-bold py-2.5 px-6 rounded-lg transition-all flex items-center gap-2"
           >
             <span className="material-symbols-outlined text-xl">photo_camera</span>
             Take Photo
@@ -203,8 +203,8 @@ export function UploadPage() {
 
       {/* Upload Session List */}
       {uploads.length > 0 && (
-        <section className="bg-card-dark rounded-xl border border-[#2A2A3E] overflow-hidden flex flex-col">
-          <div className="px-6 py-4 border-b border-[#2A2A3E] flex items-center justify-between">
+        <section className="bg-[var(--card)] rounded-xl border border-[var(--border)] overflow-hidden flex flex-col">
+          <div className="px-6 py-4 border-b border-[var(--border)] flex items-center justify-between">
             <div className="flex items-center gap-3">
               <h3 className="text-lg font-bold">Upload Session</h3>
               <span className="px-2 py-0.5 bg-primary/20 text-primary text-xs font-bold rounded-full">
@@ -218,14 +218,14 @@ export function UploadPage() {
               Clear completed
             </button>
           </div>
-          <div className="divide-y divide-[#2A2A3E]">
+          <div className="divide-y divide-[var(--border)]">
             {uploads.map((record) => (
               <div key={record.id} className="p-4 flex items-center gap-4 hover:bg-white/5 transition-colors">
                 {/* File icon */}
-                <div className={`size-12 rounded-lg bg-slate-800 flex items-center justify-center relative overflow-hidden shrink-0 ${
+                <div className={`size-12 rounded-lg bg-[var(--card)] flex items-center justify-center relative overflow-hidden shrink-0 ${
                   record.status === 'failed' ? 'grayscale' : ''
                 }`}>
-                  <span className="material-symbols-outlined text-[#8E8EA0]">{fileIcon(record.name)}</span>
+                  <span className="material-symbols-outlined text-[var(--muted-foreground)]">{fileIcon(record.name)}</span>
                   {record.status === 'complete' && (
                     <div className="absolute inset-0 bg-accent-green/10 opacity-50" />
                   )}
@@ -246,7 +246,7 @@ export function UploadPage() {
 
                   {record.status === 'uploading' ? (
                     <>
-                      <div className="w-full h-1.5 bg-[#2A2A3E] rounded-full overflow-hidden">
+                      <div className="w-full h-1.5 bg-[var(--border)] rounded-full overflow-hidden">
                         <div
                           className="bg-primary h-full transition-all duration-300"
                           style={{ width: `${record.progress}%` }}
@@ -256,14 +256,14 @@ export function UploadPage() {
                           aria-valuemax={100}
                         />
                       </div>
-                      <p className="text-[10px] text-[#8E8EA0] mt-1.5 uppercase tracking-wide font-medium">Uploading...</p>
+                      <p className="text-[10px] text-[var(--muted-foreground)] mt-1.5 uppercase tracking-wide font-medium">Uploading...</p>
                     </>
                   ) : (
                     <p className={`text-xs flex items-center gap-2 ${
-                      record.status === 'failed' ? 'text-[#FF6B6B]/80' : 'text-[#8E8EA0]'
+                      record.status === 'failed' ? 'text-[#FF6B6B]/80' : 'text-[var(--muted-foreground)]'
                     }`}>
                       <span>{fmtSize(record.size)}</span>
-                      <span className="size-1 rounded-full bg-[#2A2A3E]" />
+                      <span className="size-1 rounded-full bg-[var(--border)]" />
                       {record.status === 'complete' && record.extractionInfo && (
                         <span className="text-primary">{record.extractionInfo}</span>
                       )}
@@ -283,16 +283,16 @@ export function UploadPage() {
                     >
                       <span className="material-symbols-outlined">refresh</span>
                     </button>
-                    <button className="p-2 text-[#8E8EA0] hover:text-white">
+                    <button className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
                       <span className="material-symbols-outlined">more_vert</span>
                     </button>
                   </div>
                 ) : record.status === 'uploading' ? (
-                  <button className="p-2 text-[#8E8EA0] hover:text-white">
+                  <button className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
                     <span className="material-symbols-outlined">close</span>
                   </button>
                 ) : (
-                  <button className="p-2 text-[#8E8EA0] hover:text-white">
+                  <button className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
                     <span className="material-symbols-outlined">more_vert</span>
                   </button>
                 )}
@@ -304,20 +304,20 @@ export function UploadPage() {
 
       {/* Bottom Action Bar */}
       {uploads.length > 0 && (
-        <div className="mt-4 p-6 bg-card-dark rounded-xl border border-[#2A2A3E] flex items-center justify-between shadow-2xl">
+        <div className="mt-4 p-6 bg-[var(--card)] rounded-xl border border-[var(--border)] flex items-center justify-between shadow-2xl">
           <div className="flex items-center gap-4">
             <div className="size-10 rounded-full bg-accent-green/20 flex items-center justify-center text-accent-green">
               <span className="material-symbols-outlined">done_all</span>
             </div>
             <div>
               <p className="font-bold">{completedCount} of {totalCount} files processed</p>
-              <p className="text-xs text-[#8E8EA0]">Ready to move to review queue</p>
+              <p className="text-xs text-[var(--muted-foreground)]">Ready to move to review queue</p>
             </div>
           </div>
           <div className="flex items-center gap-3">
             <button
               onClick={() => setUploads([])}
-              className="px-6 py-2.5 bg-[#2A2A3E] hover:bg-[#2A2A3E]/70 text-[#F0F0F5] font-bold rounded-lg transition-all"
+              className="px-6 py-2.5 bg-[var(--border)] hover:bg-[var(--border)]/70 text-[var(--foreground)] font-bold rounded-lg transition-all"
             >
               Cancel All
             </button>


### PR DESCRIPTION
## Summary
- Default to light mode (dark toggle available, persisted in localStorage)
- Replace all hardcoded dark-only colors with CSS variable references (`var(--background)`, `var(--card)`, `var(--sidebar)`, etc.) that respond to `.dark` class
- Remove "Shen Lab", "MGH Neuroscience", "Dr. Aris Thorne" — Lab Manager is a generic template product
- 10 component files updated (Header, Sidebar, SkeletonTable, App + 6 pages)

## Test plan
- [ ] Verify light mode renders correctly on all pages
- [ ] Toggle dark mode, verify all pages render correctly
- [ ] Refresh page, verify dark mode preference persists
- [ ] Check no "Shen Lab" or "MGH" text remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)