### PR TITLE
fix(deploy): guard static assets dir before mounting

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -603,11 +603,13 @@ def create_app() -> FastAPI:
     DIST_DIR = STATIC_DIR / "dist"
     if DIST_DIR.is_dir():  # pragma: no cover — depends on React build artifacts
         # Serve bundled JS/CSS assets from dist/assets/
-        app.mount(
-            "/assets",
-            StaticFiles(directory=str(DIST_DIR / "assets")),
-            name="dist-assets",
-        )
+        assets_dir = DIST_DIR / "assets"
+        if assets_dir.is_dir():
+            app.mount(
+                "/assets",
+                StaticFiles(directory=str(assets_dir)),
+                name="dist-assets",
+            )
 
         # Serve icons from static/icons/
         icons_dir = STATIC_DIR / "icons"


### PR DESCRIPTION
## Summary
- Guard `dist/assets/` directory check before mounting `StaticFiles`
- Prevents `RuntimeError` on DO App Platform where React build artifacts aren't present
- App now starts in API-only mode when frontend assets aren't built

## Test plan
- [ ] Verify app starts without `dist/assets/` directory
- [ ] Verify app still serves frontend when assets are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)