### PR TITLE
chore(deploy): update app.yaml for standalone managed DB

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -19,7 +19,7 @@ services:
     envs:
       - key: DATABASE_URL
         scope: RUN_TIME
-        value: ${db.DATABASE_URL}
+        type: SECRET
       - key: MEILISEARCH_URL
         scope: RUN_TIME
         value: http://search:7700
@@ -27,6 +27,9 @@ services:
         scope: RUN_TIME
         value: ${MEILI_MASTER_KEY}
       - key: ADMIN_SECRET_KEY
+        scope: RUN_TIME
+        type: SECRET
+      - key: ADMIN_PASSWORD
         scope: RUN_TIME
         type: SECRET
       - key: MEILI_MASTER_KEY
@@ -72,9 +75,13 @@ services:
         scope: RUN_TIME
         value: "true"
 
-databases:
-  - name: db
-    engine: PG
-    version: "16"
-    size: db-s-1vcpu-1gb
-    num_nodes: 1
+# NOTE: Production uses a standalone managed database (not embedded).
+# The DATABASE_URL env var is set directly to the standalone DB URI.
+# The embedded database section below is kept as a reference for new deployments.
+# To use embedded DB, uncomment and set DATABASE_URL to ${db.DATABASE_URL}.
+# databases:
+#   - name: db
+#     engine: PG
+#     version: "16"
+#     size: db-s-1vcpu-1gb
+#     num_nodes: 1


### PR DESCRIPTION
## Summary
- Add `ADMIN_PASSWORD` to required secrets (was missing, caused runtime crash)
- Switch `DATABASE_URL` from embedded `${db.DATABASE_URL}` to standalone secret
- Comment out embedded `databases:` section — production uses standalone managed DB because embedded DB user lacks `CREATE SCHEMA` privilege

## Test plan
- [x] Production deployment is ACTIVE 9/9 with standalone DB
- [x] Health check passes: PostgreSQL, Meilisearch, disk all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)