### PR TITLE
fix: rag timeout SQL safety + vendor redundant index

### DIFF
--- a/src/lab_manager/models/vendor.py
+++ b/src/lab_manager/models/vendor.py
@@ -17,7 +17,7 @@ class Vendor(AuditMixin, table=True):
     __tablename__ = "vendors"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    name: str = Field(max_length=255, index=True, unique=True)
+    name: str = Field(max_length=255, unique=True)
     aliases: list[str] = Field(default_factory=list, sa_column=Column(sa.JSON))
     website: Optional[str] = Field(default=None, max_length=500)
     phone: Optional[str] = Field(default=None, max_length=50)

--- a/src/lab_manager/services/rag.py
+++ b/src/lab_manager/services/rag.py
@@ -378,7 +378,11 @@ def _execute_sql(db: Session, sql: str) -> list[dict]:
     if use_dedicated_readonly:
         # Dedicated readonly PG user — DB enforces SELECT-only
         with readonly_engine.connect() as conn, conn.begin():
-            conn.execute(text(f"SET LOCAL statement_timeout = '{SQL_TIMEOUT_S}s'"))
+            conn.execute(
+                text("SET LOCAL statement_timeout = :timeout").bindparams(
+                    timeout=f"{int(SQL_TIMEOUT_S)}s"
+                )
+            )
             result = conn.execute(text(sql))
             columns = list(result.keys())
             rows = [
@@ -388,7 +392,11 @@ def _execute_sql(db: Session, sql: str) -> list[dict]:
     else:
         # Fallback: main engine with application-level READ ONLY
         db.execute(text("SET TRANSACTION READ ONLY"))
-        db.execute(text(f"SET LOCAL statement_timeout = '{SQL_TIMEOUT_S}s'"))
+        db.execute(
+            text("SET LOCAL statement_timeout = :timeout").bindparams(
+                timeout=f"{int(SQL_TIMEOUT_S)}s"
+            )
+        )
         nested = db.begin_nested()
         try:
             result = db.execute(text(sql))


### PR DESCRIPTION
## Summary
- **rag.py**: cast `SQL_TIMEOUT_S` to `int` and use `bindparams` instead of f-string interpolation for `SET LOCAL statement_timeout` to prevent SQL injection
- **vendor.py**: remove redundant `index=True` on vendor name field — `unique=True` already creates a unique index

## Test plan
- [x] `ruff check src/` passes
- [ ] Verify RAG service still sets timeout correctly (manual test with `/api/ask`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)