### PR TITLE
fix(inventory): unify active status definition across services

### DIFF
--- a/src/lab_manager/models/inventory.py
+++ b/src/lab_manager/models/inventory.py
@@ -27,6 +27,11 @@ class InventoryStatus(str, enum.Enum):
     deleted = "deleted"
 
 
+# Canonical set of statuses considered "active" for stock and expiry calculations.
+# available = unopened and usable, opened = in-use but still usable.
+ACTIVE_STATUSES = frozenset({InventoryStatus.available, InventoryStatus.opened})
+
+
 class InventoryItem(AuditMixin, table=True):
     __tablename__ = "inventory"
     __table_args__ = (

--- a/src/lab_manager/services/alerts.py
+++ b/src/lab_manager/services/alerts.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from lab_manager.models.alert import Alert
 from lab_manager.models.document import Document, DocumentStatus
-from lab_manager.models.inventory import InventoryItem, InventoryStatus
+from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem, InventoryStatus
 from lab_manager.models.order import Order, OrderStatus
 from lab_manager.models.product import Product
 
@@ -27,7 +27,7 @@ def get_expiring_items(db: Session, days_ahead: int = 30) -> list[InventoryItem]
         .filter(
             InventoryItem.expiry_date.isnot(None),
             InventoryItem.expiry_date <= cutoff,
-            InventoryItem.status == InventoryStatus.available,
+            InventoryItem.status.in_(ACTIVE_STATUSES),
         )
         .all()
     )
@@ -39,7 +39,7 @@ def get_low_stock_items(db: Session, threshold: float = 1) -> list[InventoryItem
         db.query(InventoryItem)
         .filter(
             InventoryItem.quantity_on_hand <= threshold,
-            InventoryItem.status == InventoryStatus.available,
+            InventoryItem.status.in_(ACTIVE_STATUSES),
         )
         .all()
     )
@@ -59,7 +59,7 @@ def _check_expired(db: Session) -> list[dict]:
             InventoryItem.expiry_date.isnot(None),
             InventoryItem.expiry_date < today,
             InventoryItem.status.in_(
-                [InventoryStatus.available, InventoryStatus.opened]
+                ACTIVE_STATUSES
             ),
         )
         .limit(500)
@@ -93,7 +93,7 @@ def _check_expiring_soon(db: Session, days: int = 30) -> list[dict]:
             InventoryItem.expiry_date >= today,
             InventoryItem.expiry_date <= cutoff,
             InventoryItem.status.in_(
-                [InventoryStatus.available, InventoryStatus.opened]
+                ACTIVE_STATUSES
             ),
         )
         .limit(500)
@@ -129,7 +129,7 @@ def _check_out_of_stock(db: Session) -> list[dict]:
         )
         .filter(
             InventoryItem.status.in_(
-                [InventoryStatus.available, InventoryStatus.opened]
+                ACTIVE_STATUSES
             )
         )
         .group_by(InventoryItem.product_id)
@@ -172,7 +172,7 @@ def _check_low_stock(db: Session) -> list[dict]:
         )
         .filter(
             InventoryItem.status.in_(
-                [InventoryStatus.available, InventoryStatus.opened]
+                ACTIVE_STATUSES
             )
         )
         .group_by(InventoryItem.product_id)

--- a/src/lab_manager/services/analytics.py
+++ b/src/lab_manager/services/analytics.py
@@ -9,7 +9,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from lab_manager.models.document import Document, DocumentStatus
-from lab_manager.models.inventory import InventoryItem, InventoryStatus
+from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem, InventoryStatus
 from lab_manager.models.location import StorageLocation
 from lab_manager.models.order import Order, OrderItem
 from lab_manager.models.product import Product
@@ -17,8 +17,6 @@ from lab_manager.models.staff import Staff
 from lab_manager.models.vendor import Vendor
 from lab_manager.services.serialization import serialize_value as _iso
 
-# Statuses considered "active" for stock and expiry calculations.
-_ACTIVE_STATUSES = [InventoryStatus.available, InventoryStatus.opened]
 
 
 def _money(val) -> float:
@@ -111,7 +109,7 @@ def dashboard_summary(db: Session) -> dict:
         .filter(
             InventoryItem.expiry_date.isnot(None),
             InventoryItem.expiry_date <= cutoff,
-            InventoryItem.status.in_(_ACTIVE_STATUSES),
+            InventoryItem.status.in_(ACTIVE_STATUSES),
         )
         .order_by(InventoryItem.expiry_date)
         .limit(100)
@@ -136,7 +134,7 @@ def dashboard_summary(db: Session) -> dict:
             InventoryItem.product_id,
             func.sum(InventoryItem.quantity_on_hand).label("total"),
         )
-        .filter(InventoryItem.status.in_(_ACTIVE_STATUSES))
+        .filter(InventoryItem.status.in_(ACTIVE_STATUSES))
         .group_by(InventoryItem.product_id)
         .subquery()
     )

--- a/src/lab_manager/services/inventory.py
+++ b/src/lab_manager/services/inventory.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from lab_manager.exceptions import NotFoundError, ValidationError
 from lab_manager.models.consumption import ConsumptionAction, ConsumptionLog
-from lab_manager.models.inventory import InventoryItem, InventoryStatus
+from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem, InventoryStatus
 from lab_manager.models.order import Order, OrderItem, OrderStatus
 from lab_manager.models.product import Product
 
@@ -332,7 +332,7 @@ def get_stock_level(product_id: int, db: Session) -> dict:
         db.query(func.sum(InventoryItem.quantity_on_hand))
         .filter(
             InventoryItem.product_id == product_id,
-            InventoryItem.status.notin_([InventoryStatus.disposed]),
+            InventoryItem.status.in_(ACTIVE_STATUSES),
         )
         .scalar()
     )
@@ -354,7 +354,7 @@ def get_low_stock(db: Session) -> list[dict]:
         .outerjoin(
             InventoryItem,
             (InventoryItem.product_id == Product.id)
-            & (InventoryItem.status.notin_([InventoryStatus.disposed])),
+            & (InventoryItem.status.in_(ACTIVE_STATUSES)),
         )
         .filter(Product.min_stock_level.isnot(None))
         .group_by(
@@ -383,9 +383,7 @@ def get_expiring(db: Session, days: int = 30) -> list[InventoryItem]:
         .filter(
             InventoryItem.expiry_date.isnot(None),
             InventoryItem.expiry_date <= cutoff,
-            InventoryItem.status.notin_(
-                [InventoryStatus.disposed, InventoryStatus.depleted]
-            ),
+            InventoryItem.status.in_(ACTIVE_STATUSES),
         )
         .all()
     )


### PR DESCRIPTION
## Summary
- Add canonical `ACTIVE_STATUSES = frozenset({available, opened})` to `models/inventory.py`
- Update `analytics.py`, `alerts.py`, and `inventory.py` to use the shared constant
- Fix `inventory.py` queries that used `notin_([disposed])` — this silently included depleted, expired, and deleted items in stock totals

## What changed
| Service | Before | After |
|---------|--------|-------|
| analytics.py | `_ACTIVE_STATUSES = [available, opened]` (local) | imports `ACTIVE_STATUSES` |
| alerts.py (legacy helpers) | `== available` (missed opened items) | `.in_(ACTIVE_STATUSES)` |
| alerts.py (check functions) | `[available, opened]` (inline, correct) | `ACTIVE_STATUSES` |
| inventory.py (get_stock_level) | `.notin_([disposed])` (included depleted/expired/deleted) | `.in_(ACTIVE_STATUSES)` |
| inventory.py (get_low_stock) | `.notin_([disposed])` (included depleted/expired/deleted) | `.in_(ACTIVE_STATUSES)` |
| inventory.py (get_expiring) | `.notin_([disposed, depleted])` (included expired/deleted) | `.in_(ACTIVE_STATUSES)` |

## Test plan
- [x] All 779 existing tests pass
- [ ] Manual: verify dashboard stock totals match inventory page for same product

🤖 Generated with [Claude Code](https://claude.com/claude-code)