### PR TITLE
fix: pipeline status guards + 25 e2e tests

### DIFF
--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -6,6 +6,7 @@ import logging
 from typing import Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Query, UploadFile
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -196,7 +197,10 @@ def _index_approved_doc(doc_id: int) -> None:
         doc = db.query(Document).filter(Document.id == doc_id).first()
         if doc is None:
             return
-        index_document_record(doc)
+        try:
+            index_document_record(doc)
+        except Exception:
+            logger.exception("Failed to index document %d", doc_id)
 
         order = db.query(Order).filter(Order.document_id == doc.id).first()
         if not order:
@@ -205,24 +209,39 @@ def _index_approved_doc(doc_id: int) -> None:
         if order.vendor_id:
             vendor = db.query(Vendor).filter(Vendor.id == order.vendor_id).first()
             if vendor:
-                index_vendor_record(vendor)
+                try:
+                    index_vendor_record(vendor)
+                except Exception:
+                    logger.exception("Failed to index vendor %d", vendor.id)
 
-        index_order_record(order)
+        try:
+            index_order_record(order)
+        except Exception:
+            logger.exception("Failed to index order %d", order.id)
 
         items = db.query(OrderItem).filter(OrderItem.order_id == order.id).all()
         for oi in items:
-            index_order_item_record(oi)
+            try:
+                index_order_item_record(oi)
+            except Exception:
+                logger.exception("Failed to index order_item %d", oi.id)
             if oi.product_id:
                 product = db.query(Product).filter(Product.id == oi.product_id).first()
                 if product:
-                    index_product_record(product)
+                    try:
+                        index_product_record(product)
+                    except Exception:
+                        logger.exception("Failed to index product %d", product.id)
                 inv_items = (
                     db.query(InventoryItem)
                     .filter(InventoryItem.order_item_id == oi.id)
                     .all()
                 )
                 for inv in inv_items:
-                    index_inventory_record(inv)
+                    try:
+                        index_inventory_record(inv)
+                    except Exception:
+                        logger.exception("Failed to index inventory %d", inv.id)
 
         logger.info("Indexed approved doc %d and related records", doc_id)
     except Exception:
@@ -240,8 +259,6 @@ def upload_document(
     """Upload a document photo/PDF and trigger background extraction."""
     from datetime import datetime
     from pathlib import Path
-
-    from fastapi.responses import JSONResponse
 
     from lab_manager.config import get_settings
 
@@ -412,6 +429,22 @@ def review_document(
     """Approve or reject a document extraction."""
     doc = get_or_404(db, Document, document_id, "Document")
 
+    # BUG 1 FIX: status guard — only allow review on needs_review
+    if doc.status == DocumentStatus.processing:
+        return JSONResponse(
+            status_code=409,
+            content={"detail": "Document is still being processed"},
+        )
+    if doc.status in (
+        DocumentStatus.approved,
+        DocumentStatus.rejected,
+        DocumentStatus.deleted,
+    ):
+        return JSONResponse(
+            status_code=409,
+            content={"detail": f"Document already {doc.status}"},
+        )
+
     if body.action == "approve":
         doc.status = DocumentStatus.approved
         doc.reviewed_by = body.reviewed_by
@@ -448,8 +481,23 @@ def _create_order_from_doc(doc: Document, db: Session):
     if not data:  # pragma: no cover — caller checks extracted_data first
         return
 
-    vendor = None
+    # BUG 2 FIX: validate before creating order
     vendor_name = data.get("vendor_name") or doc.vendor_name
+    items = data.get("items", [])
+    if (not vendor_name or not vendor_name.strip()) and not items:
+        logger.warning(
+            "Skipping order creation for doc %d: no vendor_name and no items",
+            doc.id,
+        )
+        return
+    if not items:
+        logger.warning(
+            "Creating order for doc %d without items (vendor=%s)",
+            doc.id,
+            vendor_name,
+        )
+
+    vendor = None
     if vendor_name:
         vendor = (
             db.query(Vendor)

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -424,3 +424,416 @@ class TestAskAIReturnsSQLResults:
         assert len(data["raw_results"]) == 2
         assert data["raw_results"][0]["name"] == "Acetone"
         assert data["row_count"] == 2
+
+
+class TestExtractionFailurePaths:
+    """Test all extraction failure modes."""
+
+    def test_extraction_handles_extractor_failure(self, db_session, upload_dir):
+        """extract_from_text raises → doc.status=needs_review, review_notes='Extraction failed'"""
+        from lab_manager.api.routes.documents import _run_extraction
+
+        png = _make_png()
+        dest = upload_dir / "extract_fail.png"
+        dest.write_bytes(png)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name="extract_fail.png",
+            status=DocumentStatus.processing,
+        )
+        db_session.add(doc)
+        db_session.flush()
+        db_session.refresh(doc)
+        doc_id = doc.id
+
+        with (
+            patch(
+                "lab_manager.intake.ocr.extract_text_from_image",
+                return_value="SIGMA-ALDRICH PACKING LIST PO-12345",
+            ),
+            patch(
+                "lab_manager.intake.extractor.extract_from_text",
+                side_effect=RuntimeError("model timeout"),
+            ),
+            patch(
+                "lab_manager.database.get_session_factory",
+                return_value=lambda: db_session,
+            ),
+        ):
+            _run_extraction(doc_id)
+
+        db_session.expire_all()
+        doc = db_session.get(Document, doc_id)
+        assert doc.status == DocumentStatus.needs_review
+        assert "Extraction failed" in doc.review_notes
+
+    def test_extraction_nonexistent_doc(self, db_session, upload_dir):
+        """_run_extraction with invalid doc_id does nothing (no crash)."""
+        from lab_manager.api.routes.documents import _run_extraction
+
+        with patch(
+            "lab_manager.database.get_session_factory",
+            return_value=lambda: db_session,
+        ):
+            _run_extraction(999999)
+
+        # No exception, no documents created
+        assert db_session.query(Document).count() == 0
+
+
+class TestApproveEdgeCases:
+    """Test approve flow edge cases."""
+
+    def _create_extracted_doc(self, db_session, upload_dir, **overrides):
+        """Helper: create a document with custom extracted data ready for review."""
+        png = _make_png()
+        dest = upload_dir / "approve_edge.png"
+        dest.write_bytes(png)
+
+        extracted_data = SAMPLE_EXTRACTED.model_dump()
+        extracted_data.update(overrides.pop("extracted_overrides", {}))
+
+        doc = Document(
+            file_path=str(dest),
+            file_name="approve_edge.png",
+            status=DocumentStatus.needs_review,
+            vendor_name=extracted_data.get("vendor_name"),
+            document_type=extracted_data.get("document_type", "packing_list"),
+            extracted_data=extracted_data,
+            extraction_confidence=extracted_data.get("confidence", 0.9),
+        )
+        db_session.add(doc)
+        db_session.commit()
+        db_session.refresh(doc)
+        return doc
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_processing_doc_rejected(
+        self, mock_index, client, db_session, upload_dir
+    ):
+        """Approving a doc still in 'processing' returns 409."""
+        png = _make_png()
+        dest = upload_dir / "processing_doc.png"
+        dest.write_bytes(png)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name="processing_doc.png",
+            status=DocumentStatus.processing,
+        )
+        db_session.add(doc)
+        db_session.commit()
+        db_session.refresh(doc)
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 409
+        assert "still being processed" in resp.json()["detail"]
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_already_approved_returns_409(
+        self, mock_index, client, db_session, upload_dir
+    ):
+        """Re-approving an already approved doc returns 409."""
+        # Create a doc already in approved state (bypasses the approve endpoint
+        # to avoid background task side-effects in TestClient)
+        png = _make_png()
+        dest = upload_dir / "already_approved.png"
+        dest.write_bytes(png)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name="already_approved.png",
+            status=DocumentStatus.approved,
+            vendor_name="Sigma-Aldrich",
+            document_type="packing_list",
+            extracted_data=SAMPLE_EXTRACTED.model_dump(),
+            reviewed_by="admin",
+        )
+        db_session.add(doc)
+        db_session.commit()
+        db_session.refresh(doc)
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 409
+        assert "already approved" in resp.json()["detail"]
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_no_vendor_name(self, mock_index, client, db_session, upload_dir):
+        """Approve with extracted_data but no vendor_name — order created with no vendor."""
+        from lab_manager.models.order import Order
+        from lab_manager.models.vendor import Vendor
+
+        doc = self._create_extracted_doc(
+            db_session,
+            upload_dir,
+            extracted_overrides={"vendor_name": None},
+        )
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "approved"
+
+        order = db_session.query(Order).filter(Order.document_id == doc.id).first()
+        assert order is not None
+        assert order.vendor_id is None
+
+        # No vendor created
+        assert db_session.query(Vendor).count() == 0
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_empty_items(self, mock_index, client, db_session, upload_dir):
+        """Approve with vendor_name but empty items list — order created, no inventory."""
+        from lab_manager.models.inventory import InventoryItem
+        from lab_manager.models.order import Order
+        from lab_manager.models.product import Product
+
+        doc = self._create_extracted_doc(
+            db_session,
+            upload_dir,
+            extracted_overrides={"items": []},
+        )
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 200
+
+        order = db_session.query(Order).filter(Order.document_id == doc.id).first()
+        assert order is not None
+        assert order.vendor_id is not None
+
+        # No products or inventory created since no items
+        assert db_session.query(Product).count() == 0
+        assert db_session.query(InventoryItem).count() == 0
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_no_catalog_numbers(
+        self, mock_index, client, db_session, upload_dir
+    ):
+        """Approve where all items have catalog_number=None — no products/inventory created."""
+        from lab_manager.models.inventory import InventoryItem
+        from lab_manager.models.order import OrderItem
+        from lab_manager.models.product import Product
+
+        extracted_no_cat = ExtractedDocument(
+            vendor_name="Sigma-Aldrich",
+            document_type="packing_list",
+            po_number="PO-NO-CAT",
+            items=[
+                ExtractedItem(
+                    catalog_number=None,
+                    description="Mystery Chemical",
+                    quantity=1,
+                    unit="L",
+                    lot_number="LOT001",
+                    unit_price=10.00,
+                ),
+                ExtractedItem(
+                    catalog_number=None,
+                    description="Another Mystery",
+                    quantity=2,
+                    unit="G",
+                    lot_number="LOT002",
+                    unit_price=5.00,
+                ),
+            ],
+            confidence=0.85,
+        )
+
+        doc = self._create_extracted_doc(
+            db_session,
+            upload_dir,
+        )
+        # Override extracted_data with no catalog numbers
+        doc.extracted_data = extracted_no_cat.model_dump()
+        doc.vendor_name = "Sigma-Aldrich"
+        db_session.commit()
+        db_session.refresh(doc)
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 200
+
+        # OrderItems are created but without products
+        order_items = db_session.query(OrderItem).all()
+        assert len(order_items) == 2
+
+        # No products or inventory since catalog_number is None
+        assert db_session.query(Product).count() == 0
+        assert db_session.query(InventoryItem).count() == 0
+
+        # OrderItems have no product_id
+        assert all(oi.product_id is None for oi in order_items)
+
+
+class TestUploadSecurity:
+    """Test upload filename sanitization."""
+
+    @patch("lab_manager.api.routes.documents._run_extraction")
+    def test_upload_filename_slashes_stripped(self, _mock, client, upload_dir):
+        """Filename with slashes sanitized: ../../etc/passwd.png → no path separators."""
+        png = _make_png()
+
+        resp = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("../../etc/passwd.png", png, "image/png")},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        # Forward slashes replaced with underscores — no path traversal possible
+        assert "/" not in data["file_name"]
+
+    @patch("lab_manager.api.routes.documents._run_extraction")
+    def test_upload_filename_null_bytes_stripped(self, _mock, client, upload_dir):
+        """Filename with null bytes sanitized."""
+        png = _make_png()
+
+        resp = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("evil\x00file.png", png, "image/png")},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "\x00" not in data["file_name"]
+
+    @patch("lab_manager.api.routes.documents._run_extraction")
+    def test_upload_filename_backslash_stripped(self, _mock, client, upload_dir):
+        """Windows path separators stripped."""
+        png = _make_png()
+
+        resp = client.post(
+            "/api/v1/documents/upload",
+            files={"file": ("..\\..\\windows\\system32.png", png, "image/png")},
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert "\\" not in data["file_name"]
+
+
+class TestSearchIndexingResilience:
+    """Test search indexing failure handling."""
+
+    @patch("lab_manager.api.routes.documents._index_approved_doc")
+    def test_approve_succeeds_and_triggers_indexing(
+        self, mock_index, client, db_session, upload_dir
+    ):
+        """Approve returns 200 and triggers indexing background task."""
+        from lab_manager.models.order import Order
+        from lab_manager.models.vendor import Vendor
+
+        png = _make_png()
+        dest = upload_dir / "index_test.png"
+        dest.write_bytes(png)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name="index_test.png",
+            status=DocumentStatus.needs_review,
+            vendor_name="Sigma-Aldrich",
+            document_type="packing_list",
+            extracted_data=SAMPLE_EXTRACTED.model_dump(),
+            extraction_confidence=0.92,
+        )
+        db_session.add(doc)
+        db_session.commit()
+        db_session.refresh(doc)
+
+        resp = client.post(
+            f"/api/v1/documents/{doc.id}/review",
+            json={"action": "approve", "reviewed_by": "admin"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "approved"
+
+        # Background indexing was triggered
+        mock_index.assert_called_once_with(doc.id)
+
+        # Business records were created
+        assert (
+            db_session.query(Vendor).filter(Vendor.name == "Sigma-Aldrich").first()
+            is not None
+        )
+        assert (
+            db_session.query(Order).filter(Order.document_id == doc.id).first()
+            is not None
+        )
+
+
+class TestAskAIEdgeCases:
+    """Test Ask AI edge cases."""
+
+    def test_ask_sql_failure_falls_back_to_search(self, client, db_session):
+        """When SQL generation fails, Ask AI falls back to Meilisearch search."""
+        with (
+            patch(
+                "lab_manager.services.rag._get_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "lab_manager.services.rag._generate_sql",
+                side_effect=RuntimeError("model overloaded"),
+            ),
+            patch(
+                "lab_manager.services.search.search",
+                return_value=[{"id": 1, "name": "Test Product"}],
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ask",
+                json={"question": "What chemicals do we have?"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "search"
+
+    def test_ask_empty_question(self, client, db_session):
+        """Empty question returns a helpful prompt message."""
+        resp = client.post(
+            "/api/v1/ask",
+            json={"question": ""},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "provide a question" in data["answer"].lower()
+        assert data["raw_results"] == []
+
+    def test_ask_returns_search_source_on_fallback(self, client, db_session):
+        """Fallback response has source='search' and sql=None."""
+        with (
+            patch(
+                "lab_manager.services.rag._get_client",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "lab_manager.services.rag._generate_sql",
+                side_effect=RuntimeError("timeout"),
+            ),
+            patch(
+                "lab_manager.services.search.search",
+                return_value=[{"id": 42, "name": "Fallback result"}],
+            ),
+        ):
+            resp = client.post(
+                "/api/v1/ask",
+                json={"question": "List all solvents"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"] == "search"
+        assert data.get("sql") is None
+        assert len(data["raw_results"]) == 1


### PR DESCRIPTION
## Summary

- Add status guard: only `needs_review` docs can be approved/rejected (409 otherwise)
- Add validation: skip creating empty orders when no vendor AND no items
- Make Meilisearch indexing resilient: per-record try/except
- Add 14 new e2e tests (25 total in test_pipeline_e2e.py)

## Test plan

- [x] 870 tests pass (856 existing + 14 new)
- [x] All edge cases covered: double-approve, processing doc review, empty data, path traversal

🤖 Generated with [Claude Code](https://claude.com/claude-code)