### PR TITLE
fix(web): memory leak, stale closure, error boundary, FormData header

### DIFF
--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -28,8 +28,13 @@ export function Sidebar({
   reviewCount = 0,
 }: SidebarProps) {
   const handleLogout = async () => {
-    await auth.logout()
-    window.location.reload()
+    try {
+      await auth.logout()
+    } catch {
+      // Swallow logout errors — still reload to clear session
+    } finally {
+      window.location.reload()
+    }
   }
 
   return (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -144,12 +144,16 @@ export interface AskResponse {
 async function apiFetch<T>(url: string, opts?: RequestInit): Promise<T> {
   // Ensure trailing slash for FastAPI compatibility
   const cleanUrl = url.endsWith('/') || opts?.method === 'POST' || url.includes('?') ? url : url + '/'
+  const headers: Record<string, string> = {
+    ...opts?.headers,
+  }
+  // Only set Content-Type for non-FormData bodies
+  if (!(opts?.body instanceof FormData)) {
+    headers['Content-Type'] = 'application/json'
+  }
   const res = await fetch(`${BASE}${cleanUrl}`, {
     ...opts,
-    headers: {
-      'Content-Type': 'application/json',
-      ...opts?.headers,
-    },
+    headers,
   })
   if (res.status === 401) {
     throw new Error('Unauthorized')

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,4 @@
-import { StrictMode } from 'react'
+import { StrictMode, Component, type ReactNode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query'
@@ -7,12 +7,51 @@ import App from './App.tsx'
 
 const queryClient = new QueryClient()
 
+interface ErrorBoundaryState {
+  hasError: boolean
+  error?: Error
+}
+
+class ErrorBoundary extends Component<{ readonly children: ReactNode }, ErrorBoundaryState> {
+  constructor(props: { readonly children: ReactNode }) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center min-h-screen bg-slate-900 text-white p-8">
+          <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
+          <p className="text-slate-400 mb-6 text-center max-w-md">
+            {this.state.error?.message ?? 'An unexpected error occurred'}
+          </p>
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-6 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg font-semibold transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/web/src/pages/AskPage.tsx
+++ b/web/src/pages/AskPage.tsx
@@ -127,6 +127,8 @@ export function AskPage({ onError }: Readonly<AskPageProps>) {
   const [submitting, setSubmitting] = useState(false)
   const [localError, setLocalError] = useState<string | null>(null)
   const transcriptRef = useRef<HTMLDivElement | null>(null)
+  const turnsRef = useRef(turns)
+  turnsRef.current = turns
 
   const canSubmit = question.trim().length > 0 && question.length <= MAX_QUESTION_LENGTH && !submitting
   const remainingChars = MAX_QUESTION_LENGTH - question.length
@@ -169,7 +171,7 @@ export function AskPage({ onError }: Readonly<AskPageProps>) {
     setQuestion('')
 
     try {
-      const response = (await ask.query(buildContextualQuestion(turns, trimmed))) as AskResponse
+      const response = (await ask.query(buildContextualQuestion(turnsRef.current, trimmed))) as AskResponse
       setTurns((current) =>
         current.map((turn) =>
           turn.id === turnId

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { documents, type Document as AppDocument } from '@/lib/api'
 
@@ -33,6 +33,16 @@ export function UploadPage() {
   const fileRef = useRef<HTMLInputElement>(null)
   const cameraRef = useRef<HTMLInputElement>(null)
   const navigate = useNavigate()
+  const intervalsRef = useRef<Set<ReturnType<typeof setInterval>>>(new Set())
+
+  useEffect(() => {
+    return () => {
+      for (const interval of intervalsRef.current) {
+        clearInterval(interval)
+      }
+      intervalsRef.current.clear()
+    }
+  }, [])
 
   const pollDocument = useCallback((uploadId: number, docId: number) => {
     const interval = setInterval(async () => {
@@ -41,6 +51,7 @@ export function UploadPage() {
         const finalStatuses = ['needs_review', 'extracted', 'approved', 'ocr_failed', 'rejected']
         if (finalStatuses.includes(doc.status ?? '')) {
           clearInterval(interval)
+          intervalsRef.current.delete(interval)
           setUploads((prev) => prev.map((u) => u.id === uploadId ? {
             ...u,
             status: doc.status === 'ocr_failed' ? 'failed' : 'complete',
@@ -68,7 +79,7 @@ export function UploadPage() {
         // Swallow poll errors — the upload itself succeeded
       }
     }, 3000)
-    return () => clearInterval(interval)
+    intervalsRef.current.add(interval)
   }, [])
 
   const processFile = useCallback(async (file: File) => {


### PR DESCRIPTION
## Summary
- CRITICAL: UploadPage polling intervals now cleaned up on unmount
- CRITICAL: AskPage uses ref to always read latest turns state
- HIGH: ErrorBoundary catches rendering crashes with retry UI
- HIGH: apiFetch no longer overrides Content-Type for FormData
- HIGH: Logout error handling prevents unhandled rejection

## Test plan
- [ ] Upload page: navigate away during processing — no console errors
- [ ] Ask page: rapid question submission maintains context
- [ ] Trigger render error — error boundary shows fallback
- [ ] File upload still works (FormData Content-Type)

Generated with Claude Code