### PR TITLE
ci: add frontend type-check, build, and test job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,38 @@ permissions:
   contents: read
 
 jobs:
+  frontend:
+    name: Frontend (lint, build, test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install dependencies
+        working-directory: web/
+        run: npm ci
+
+      - name: Type check
+        working-directory: web/
+        run: npx tsc --noEmit
+
+      - name: Build
+        working-directory: web/
+        run: npm run build
+
+      - name: Test
+        working-directory: web/
+        run: npm test
+
   lint:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,6 +38,7 @@ jobs:
         run: uv sync --dev --frozen
 
       - name: Audit dependencies
+        # CVE-2025-69872: False positive in dev-only dependency, not exploitable in production
         run: uv run --dev --with pip-audit pip-audit --progress-spinner off --ignore CVE-2025-69872
 
   bandit:


### PR DESCRIPTION
## Summary
- Adds frontend CI job running TypeScript check, production build, and vitest
- Catches TypeScript errors and build failures before merge
- Documents CVE suppression in security workflow

## Test plan
- [ ] CI runs frontend job on next push
- [ ] TypeScript errors block merge
- [ ] Test failures block merge

🤖 Generated with Claude Code