### PR TITLE
fix(deploy): pg_isready fails with +psycopg driver suffix in DATABASE_URL

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,9 @@ set -e
 echo "[entrypoint] Waiting for database..."
 MAX_RETRIES=30
 RETRY=0
-until pg_isready -d "$DATABASE_URL" -q 2>/dev/null; do
+# Strip SQLAlchemy driver suffix (+psycopg) - pg_isready only understands postgresql://
+PG_URL=$(echo "$DATABASE_URL" | sed 's/+psycopg//')
+until pg_isready -d "$PG_URL" -q 2>/dev/null; do
     RETRY=$((RETRY + 1))
     if [ "$RETRY" -ge "$MAX_RETRIES" ]; then
         echo "[entrypoint] ERROR: database not ready after ${MAX_RETRIES} attempts"


### PR DESCRIPTION
## Summary
Container entrypoint used pg_isready with the full SQLAlchemy DATABASE_URL including +psycopg driver suffix. pg_isready can't parse this, causing the container to never pass the readiness gate.

Fix: Strip the driver suffix before passing to pg_isready.

## Test plan
- [ ] docker compose up starts successfully
- [ ] Container logs show 'Database ready' before app start

🤖 Generated with Claude Code