### PR TITLE
fix(deploy): MEILISEARCH_API_KEY literal string in DO app spec

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -25,7 +25,8 @@ services:
         value: http://search:7700
       - key: MEILISEARCH_API_KEY
         scope: RUN_TIME
-        value: ${MEILI_MASTER_KEY}
+        type: SECRET
+        value: changeme-meilisearch-key
       - key: ADMIN_SECRET_KEY
         scope: RUN_TIME
         type: SECRET


### PR DESCRIPTION
## Summary
DO App Platform doesn't interpolate `${VAR}` in env values. MEILISEARCH_API_KEY was receiving the literal string `${MEILI_MASTER_KEY}` instead of the actual key, causing 403 on all Meilisearch operations.

Changed to a separate SECRET env var that operators set during deployment.

## Test plan
- [ ] Deploy to DO — search operations return 200 (not 403)
- [ ] Meilisearch indexing works on document approval

🤖 Generated with Claude Code