### PR TITLE
fix(db): resolve alembic revision ID collision

### DIFF
--- a/alembic/versions/4ecede3a6f58_add_equipment_table.py
+++ b/alembic/versions/4ecede3a6f58_add_equipment_table.py
@@ -1,7 +1,7 @@
 """add equipment table
 
 Revision ID: 4ecede3a6f58
-Revises: a1b2c3d4e5f6
+Revises: b2c3d4e5f6a7
 Create Date: 2026-03-17 09:16:55.165098
 
 """
@@ -14,7 +14,7 @@ import sqlmodel
 
 # revision identifiers, used by Alembic.
 revision: str = "4ecede3a6f58"
-down_revision: Union[str, None] = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "b2c3d4e5f6a7"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/b2c3d4e5f6a7_add_processing_status.py
+++ b/alembic/versions/b2c3d4e5f6a7_add_processing_status.py
@@ -1,14 +1,14 @@
 """Add processing to documents status CHECK constraint.
 
-Revision ID: a1b2c3d4e5f6
-Revises: f6a7b8c9d0e1
+Revision ID: b2c3d4e5f6a7
+Revises: a1b2c3d4e5f6
 Create Date: 2026-03-19
 """
 
 from alembic import op
 
-revision = "a1b2c3d4e5f6"
-down_revision = "f6a7b8c9d0e1"
+revision = "b2c3d4e5f6a7"
+down_revision = "a1b2c3d4e5f6"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary
Two migration files had identical revision IDs (`a1b2c3d4e5f6`):
- `add_password_hash_to_staff` (2026-03-16)
- `add_processing_status` (2026-03-19)

Assigned unique ID `b2c3d4e5f6a7` to processing_status migration and updated the dependency chain.

Chain: `...f6a7b8c9d0e1 → a1b2c3d4e5f6 (password) → b2c3d4e5f6a7 (processing) → 4ecede3a6f58 (equipment) → ...`

## Test plan
- [x] `alembic heads` shows single head
- [ ] `alembic upgrade head` succeeds on fresh DB
- [ ] `alembic downgrade base` succeeds

Generated with Claude Code