### PR TITLE
test(web): fix 26 stale frontend tests

### DIFF
--- a/web/src/__tests__/api.test.ts
+++ b/web/src/__tests__/api.test.ts
@@ -20,7 +20,7 @@ describe('api client', () => {
     it('list calls GET /documents with pagination params', async () => {
       const result = await documents.list(1, 20)
       expect(result.items).toHaveLength(2)
-      expect(result.items![0].filename).toBe('invoice_001.pdf')
+      expect(result.items![0].file_name).toBe('invoice_001.pdf')
       expect(result.total).toBe(2)
       expect(result.page).toBe(1)
     })
@@ -28,7 +28,7 @@ describe('api client', () => {
     it('list with status filter passes status param', async () => {
       const result = await documents.list(1, 20, 'needs_review')
       expect(result.items).toHaveLength(2)
-      expect(result.items![0].filename).toBe('review_doc_1.pdf')
+      expect(result.items![0].file_name).toBe('review_doc_1.pdf')
     })
 
     it('review calls POST /documents/{id}/review with action body', async () => {
@@ -40,7 +40,7 @@ describe('api client', () => {
     it('upload sends FormData to POST /documents/upload', async () => {
       const file = new File(['test content'], 'test.pdf', { type: 'application/pdf' })
       const result = await documents.upload(file)
-      expect(result).toEqual({ id: 99, filename: 'uploaded.pdf', status: 'pending' })
+      expect(result).toEqual({ id: 99, file_name: 'uploaded.pdf', status: 'pending' })
     })
   })
 

--- a/web/src/__tests__/upload.test.tsx
+++ b/web/src/__tests__/upload.test.tsx
@@ -96,10 +96,11 @@ describe('UploadPage', () => {
         http.post('/api/v1/documents/upload', () => {
           return HttpResponse.json({
             id: 99,
-            filename: 'test_invoice.pdf',
+            file_name: 'test_invoice.pdf',
             vendor_name: 'TestVendor',
             document_type: 'invoice',
-            status: 'pending',
+            status: 'needs_review',
+            extraction_confidence: 0.85,
           })
         }),
       )
@@ -181,16 +182,30 @@ describe('UploadPage', () => {
       // The progress bar should appear while uploading
       await waitFor(() => {
         const progressBar = screen.queryByRole('progressbar')
-        const uploadingText = screen.queryByText('Uploading...')
+        const uploadingTexts = screen.queryAllByText('Uploading...')
         // Either progressbar or uploading text or processing text should be present
         expect(
-          progressBar || uploadingText || screen.queryByText(/Processing AI/i),
+          progressBar || uploadingTexts.length > 0 || screen.queryByText(/Processing AI/i),
         ).toBeTruthy()
       })
     })
 
     it('shows completed files count in the bottom bar', async () => {
       const user = userEvent.setup()
+
+      server.use(
+        http.post('/api/v1/documents/upload', () => {
+          return HttpResponse.json({
+            id: 99,
+            file_name: 'invoice.pdf',
+            vendor_name: 'TestVendor',
+            document_type: 'invoice',
+            status: 'needs_review',
+            extraction_confidence: 0.85,
+          })
+        }),
+      )
+
       renderUpload()
 
       const file = createMockFile('invoice.pdf', 1024, 'application/pdf')

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -46,16 +46,16 @@ const mockInventory = {
 
 const mockDocuments = {
   items: [
-    { id: 1, filename: 'invoice_001.pdf', vendor_name: 'Sigma-Aldrich', document_type: 'invoice', status: 'approved', confidence: 0.95, created_at: '2026-03-15T10:00:00' },
-    { id: 2, filename: 'packing_list_002.pdf', vendor_name: 'Fisher Scientific', document_type: 'packing_list', status: 'needs_review', confidence: 0.72, created_at: '2026-03-18T14:30:00' },
+    { id: 1, file_name: 'invoice_001.pdf', vendor_name: 'Sigma-Aldrich', document_type: 'invoice', status: 'approved', extraction_confidence: 0.95, created_at: '2026-03-15T10:00:00' },
+    { id: 2, file_name: 'packing_list_002.pdf', vendor_name: 'Fisher Scientific', document_type: 'packing_list', status: 'needs_review', extraction_confidence: 0.72, created_at: '2026-03-18T14:30:00' },
   ],
   total: 2, page: 1, page_size: 20, pages: 1,
 }
 
 const mockReviewQueue = {
   items: [
-    { id: 10, filename: 'review_doc_1.pdf', vendor_name: 'Sigma-Aldrich', document_type: 'invoice', status: 'needs_review', confidence: 0.65, created_at: '2026-03-19T09:00:00' },
-    { id: 11, filename: 'review_doc_2.pdf', vendor_name: 'Fisher Scientific', document_type: 'packing_list', status: 'needs_review', confidence: 0.88, created_at: '2026-03-19T10:00:00' },
+    { id: 10, file_name: 'review_doc_1.pdf', vendor_name: 'Sigma-Aldrich', document_type: 'invoice', status: 'needs_review', extraction_confidence: 0.65, created_at: '2026-03-19T09:00:00' },
+    { id: 11, file_name: 'review_doc_2.pdf', vendor_name: 'Fisher Scientific', document_type: 'packing_list', status: 'needs_review', extraction_confidence: 0.88, created_at: '2026-03-19T10:00:00' },
   ],
   total: 2, page: 1, page_size: 20, pages: 1,
 }
@@ -156,7 +156,7 @@ export const handlers = [
     return d ? HttpResponse.json(d) : new HttpResponse(null, { status: 404 })
   }),
   http.post('/api/documents/:id/review', () => HttpResponse.json({ status: 'ok' })),
-  http.post('/api/v1/documents/upload', () => HttpResponse.json({ id: 99, filename: 'uploaded.pdf', status: 'pending' })),
+  http.post('/api/v1/documents/upload', () => HttpResponse.json({ id: 99, file_name: 'uploaded.pdf', status: 'pending' })),
 
   // Search
   http.get('/api/search', () => HttpResponse.json(mockSearchResults)),


### PR DESCRIPTION
## Summary
- Fixed mock data field names in `handlers.ts`: `filename` → `file_name`, `confidence` → `extraction_confidence`
- Updated upload tests to return final status (`needs_review`) instead of `pending` so the component marks uploads as complete
- Fixed progress bar test to use `queryAllByText` since there are multiple "Uploading..." elements in the DOM

3 test files (upload, review, documents) had 26 failing tests because the mock data used outdated field names that didn't match the Document interface.

## Test plan
- [x] `npx vitest run` — all 154 tests pass

🤖 Generated with Claude Code