### PR TITLE
fix(api): document PATCH returns 422 on invalid status (was 500)

### DIFF
--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -104,6 +104,13 @@ class DocumentUpdate(BaseModel):
             _validate_file_path(v)
         return v
 
+    @field_validator("status")
+    @classmethod
+    def valid_status(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_STATUSES:
+            raise ValueError(f"status must be one of {_VALID_STATUSES}")
+        return v
+
 
 class ReviewAction(BaseModel):
     action: Literal["approve", "reject"]

--- a/src/lab_manager/services/analytics.py
+++ b/src/lab_manager/services/analytics.py
@@ -9,7 +9,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from lab_manager.models.document import Document, DocumentStatus
-from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem, InventoryStatus
+from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem
 from lab_manager.models.location import StorageLocation
 from lab_manager.models.order import Order, OrderItem
 from lab_manager.models.product import Product

--- a/tests/test_coverage_final.py
+++ b/tests/test_coverage_final.py
@@ -367,6 +367,23 @@ class TestDocumentValidPathInValidator:
         )
         assert resp.status_code == 200
 
+    def test_update_document_invalid_status_returns_422(self, client, db_session):
+        from lab_manager.models.document import Document
+
+        doc = Document(
+            file_path="/tmp/original.pdf",
+            file_name="original.pdf",
+            status="pending",
+        )
+        db_session.add(doc)
+        db_session.flush()
+
+        resp = client.patch(
+            f"/api/v1/documents/{doc.id}",
+            json={"status": "bogus_status"},
+        )
+        assert resp.status_code == 422
+
     def test_approve_doc_empty_data(self, client, db_session):
         """Approve doc with empty dict as extracted_data."""
         from lab_manager.models.document import Document


### PR DESCRIPTION
## Summary
- PATCH `/api/v1/documents/{id}` with an invalid `status` value now returns **422** with a clear validation error, instead of hitting the PostgreSQL CHECK constraint and returning an unhandled **500**
- Added `field_validator("status")` to the `DocumentUpdate` Pydantic model, mirroring the existing validator on `DocumentCreate`
- Added test confirming invalid status returns 422

## Test plan
- [x] New test: `test_update_document_invalid_status_returns_422` passes
- [x] `ruff check` clean
- [x] `mypy` clean

Generated with [Claude Code](https://claude.com/claude-code)