### PR TITLE
test: isolate pipeline suites from local auth env

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,25 @@
 """Tests for document intake pipeline."""
 
+import os
 from unittest.mock import patch
 
+import pytest
+
+from lab_manager.config import get_settings
 from lab_manager.intake.pipeline import process_document
 from lab_manager.models.document import DocumentStatus
+
+
+@pytest.fixture(autouse=True)
+def _pipeline_test_settings(monkeypatch):
+    """Force pipeline tests to run with auth disabled and deterministic settings."""
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("ADMIN_SECRET_KEY", "test-secret-key-not-for-production")
+    monkeypatch.setenv("ADMIN_PASSWORD", "test-admin-password-not-for-production")
+    monkeypatch.setenv("DATABASE_URL", os.environ.get("DATABASE_URL", "sqlite://"))
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
 
 
 def test_process_document_records_failure_on_ocr_error(db_session, tmp_path):

--- a/tests/test_pipeline_e2e.py
+++ b/tests/test_pipeline_e2e.py
@@ -14,6 +14,16 @@ from lab_manager.intake.schemas import ExtractedDocument, ExtractedItem
 from lab_manager.models.document import Document, DocumentStatus
 
 
+@pytest.fixture(autouse=True)
+def _pipeline_e2e_settings(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("ADMIN_SECRET_KEY", "test-secret-key-not-for-production")
+    monkeypatch.setenv("ADMIN_PASSWORD", "test-admin-password-not-for-production")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 def _make_png() -> bytes:
     """Minimal valid 1x1 PNG."""
 


### PR DESCRIPTION
## Summary
- isolate pipeline unit and e2e suites from shell-level auth env leakage
- make full backend test run deterministic in a clean worktree

## Verified
- uv run pytest -q
- uv run pytest tests/bdd -q
- cd web && npm test && npm run lint && npm run build
- live HTTPS checklist for website/API features passed
