### PR TITLE
fix(api): increase documents page_size limit to 500

### DIFF
--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -369,7 +369,7 @@ def document_stats(db: Session = Depends(get_db)):
 @router.get("/")
 def list_documents(
     page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=200),
+    page_size: int = Query(50, ge=1, le=500),
     status: Optional[str] = Query(None),
     document_type: Optional[str] = Query(None),
     vendor_name: Optional[str] = Query(None),


### PR DESCRIPTION
## Summary
- Increase `page_size` limit from 200 to 500 for `/api/v1/documents/` endpoint
- Fixes 422 validation errors on dashboard load when frontend requests `page_size=500`

## Root Cause
Frontend requests documents with `page_size=500` but API only allowed max 200.
This caused 422 "Input should be less than or equal to 200" errors in browser console.

## Fix
Changed `le=200` to `le=500` to match audit routes which already allow 500.

## Test Plan
- [ ] Load dashboard - no 422 errors in console
- [ ] Documents list loads correctly
- [ ] Review queue (50 items) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)