### PR TITLE
fix(api): add CORS middleware for frontend dev server

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 from fastapi import APIRouter, FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from itsdangerous import BadSignature, URLSafeTimedSerializer
@@ -128,6 +129,19 @@ def create_app() -> FastAPI:
 
     # Trust X-Forwarded-* headers only from loopback (reverse proxy on same host)
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1", "::1"])
+
+    # --- CORS for frontend dev server ---
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://localhost:5173",  # Vite dev server
+            "http://127.0.0.1:5173",
+            "http://localhost:3000",  # Alternative dev port
+        ],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     # --- Rate limiting (slowapi) ---
     limiter = Limiter(key_func=get_remote_address)


### PR DESCRIPTION
## Summary
- Add CORSMiddleware to FastAPI app to allow frontend dev server (Vite on port 5173) to communicate with API
- Allows credentials for cookie-based auth
- Supports localhost:5173, 127.0.0.1:5173, and localhost:3000

## Test plan
- [x] Start frontend dev server (`cd web && bun dev`)
- [x] Start backend (`docker compose up -d`)
- [x] Navigate to http://localhost:5173
- [x] Verify no CORS errors in console
- [x] All pages load: Dashboard, Documents, Review Queue, Inventory, Orders, Upload, Ask AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)