### PR TITLE
fix(export): add .csv suffix to export route paths

### DIFF
--- a/src/lab_manager/api/routes/export.py
+++ b/src/lab_manager/api/routes/export.py
@@ -59,7 +59,7 @@ def _csv_response(rows: list[dict], filename: str) -> StreamingResponse:
     )
 
 
-@router.get("/inventory")
+@router.get("/inventory.csv")
 def export_inventory(
     location_id: Optional[int] = Query(None),
     db: Session = Depends(get_db),
@@ -68,7 +68,7 @@ def export_inventory(
     return _csv_response(rows, "inventory.csv")
 
 
-@router.get("/orders")
+@router.get("/orders.csv")
 def export_orders(
     vendor_id: Optional[int] = Query(None),
     date_from: Optional[date] = Query(None),
@@ -81,7 +81,7 @@ def export_orders(
     return _csv_response(rows, "orders.csv")
 
 
-@router.get("/products")
+@router.get("/products.csv")
 def export_products(db: Session = Depends(get_db)):
     fieldnames = [
         "id",
@@ -121,7 +121,7 @@ def export_products(db: Session = Depends(get_db)):
     )
 
 
-@router.get("/vendors")
+@router.get("/vendors.csv")
 def export_vendors(db: Session = Depends(get_db)):
     fieldnames = ["id", "name", "website", "phone", "email", "notes"]
     query = db.query(Vendor).order_by(Vendor.id).yield_per(100)


### PR DESCRIPTION
## Summary
- Add `.csv` suffix to all four export routes to match test expectations
- Routes changed: `/inventory` → `/inventory.csv`, `/orders` → `/orders.csv`, `/products` → `/products.csv`, `/vendors` → `/vendors.csv`

## Problem
Tests expected `/api/v1/export/inventory.csv` but routes were `/inventory` (no `.csv` suffix), causing 404 errors.

## Test plan
- [x] All 26 export-related tests now pass
- [x] All 20 e2e deployment tests pass
- [x] `uv run pytest tests/test_analytics.py tests/test_coverage_gaps.py::TestExportRoutes tests/bdd/step_defs/test_export.py` - 26 passed

Fixes 14 failing tests in test_analytics.py, test_coverage_gaps.py, test_e2e_deployment.py, and test_export.py BDD tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)