### PR TITLE
fix(api): add CORS middleware for Vite dev server

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 from fastapi import APIRouter, FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from itsdangerous import BadSignature, URLSafeTimedSerializer
@@ -128,6 +129,21 @@ def create_app() -> FastAPI:
 
     # Trust X-Forwarded-* headers only from loopback (reverse proxy on same host)
     app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["127.0.0.1", "::1"])
+
+    # CORS for Vite dev server (localhost:5173) and production origins
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[
+            "http://localhost:5173",  # Vite dev server
+            "http://127.0.0.1:5173",
+            "http://localhost",  # Production via Caddy
+            "http://localhost:80",
+            "https://localhost",
+        ],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 
     # --- Rate limiting (slowapi) ---
     limiter = Limiter(key_func=get_remote_address)


### PR DESCRIPTION
## Summary
- Adds CORSMiddleware to FastAPI app to allow requests from Vite dev server (localhost:5173)
- Fixes CORS errors when browser follows 307 redirects directly to backend

## Problem
When API endpoints return 307 redirects for trailing slash normalization (e.g., `/api/v1/documents` → `/api/v1/documents/`), the browser follows the redirect directly to `localhost:8000`, bypassing the Vite proxy. The backend lacked CORS headers for `localhost:5173`, causing all API calls to fail in development mode.

## Solution
Add FastAPI's CORSMiddleware with allowed origins:
- `http://localhost:5173` (Vite dev server)
- `http://127.0.0.1:5173`
- `http://localhost` (production via Caddy)
- `http://localhost:80`
- `https://localhost`

## Test Plan
- [x] All existing tests pass (31 tests)
- [ ] Manual verification in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)