### PR TITLE
fix(db): use SQLModel Session for exec() method support

### DIFF
--- a/src/lab_manager/api/deps.py
+++ b/src/lab_manager/api/deps.py
@@ -6,7 +6,7 @@ import hmac
 from typing import TypeVar
 
 from fastapi import Header, HTTPException
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.config import get_settings
 from lab_manager.database import get_db  # noqa: F401 — re-export for route imports

--- a/src/lab_manager/api/routes/alerts.py
+++ b/src/lab_manager/api/routes/alerts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, Request
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import paginate

--- a/src/lab_manager/api/routes/analytics.py
+++ b/src/lab_manager/api/routes/analytics.py
@@ -6,7 +6,7 @@ from datetime import date
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db
 from lab_manager.exceptions import NotFoundError

--- a/src/lab_manager/api/routes/ask.py
+++ b/src/lab_manager/api/routes/ask.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, Field
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db
 from lab_manager.services.rag import ask

--- a/src/lab_manager/api/routes/audit.py
+++ b/src/lab_manager/api/routes/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db
 from lab_manager.api.pagination import paginate

--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, BackgroundTasks, Depends, Query, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, field_validator
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/api/routes/equipment.py
+++ b/src/lab_manager/api/routes/equipment.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/api/routes/export.py
+++ b/src/lab_manager/api/routes/export.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import StreamingResponse
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db
 from lab_manager.services import analytics as svc

--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy.orm import Session, selectinload
+from sqlmodel import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/api/routes/orders.py
+++ b/src/lab_manager/api/routes/orders.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field, field_validator
-from sqlalchemy.orm import Session, selectinload
+from sqlmodel import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -9,7 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field as PydanticField, field_validator
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session, selectinload
+from sqlmodel import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/api/routes/telemetry.py
+++ b/src/lab_manager/api/routes/telemetry.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import func, text
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db
 from lab_manager.models.usage_event import UsageEvent

--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/src/lab_manager/database.py
+++ b/src/lab_manager/database.py
@@ -7,7 +7,8 @@ from collections.abc import Generator
 from contextlib import contextmanager
 
 from sqlalchemy import create_engine
-from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import Session
 
 from lab_manager.config import get_settings
 

--- a/src/lab_manager/intake/pipeline.py
+++ b/src/lab_manager/intake/pipeline.py
@@ -8,7 +8,7 @@ import shutil
 from pathlib import Path
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.config import get_settings
 from lab_manager.intake.extractor import extract_from_text

--- a/src/lab_manager/models/audit.py
+++ b/src/lab_manager/models/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 from sqlmodel import Field, SQLModel, Column
 from sqlalchemy import JSON
 from sqlalchemy.dialects.postgresql import JSONB as _JSONB

--- a/src/lab_manager/services/alerts.py
+++ b/src/lab_manager/services/alerts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.models.alert import Alert
 from lab_manager.models.document import Document, DocumentStatus

--- a/src/lab_manager/services/analytics.py
+++ b/src/lab_manager/services/analytics.py
@@ -6,7 +6,7 @@ from datetime import date, timedelta
 from typing import Optional
 
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.models.document import Document, DocumentStatus
 from lab_manager.models.inventory import ACTIVE_STATUSES, InventoryItem

--- a/src/lab_manager/services/audit.py
+++ b/src/lab_manager/services/audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import contextvars
 
 from sqlalchemy import event, inspect
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.models.audit import AuditLog
 from lab_manager.models.base import AuditMixin, utcnow

--- a/src/lab_manager/services/orders.py
+++ b/src/lab_manager/services/orders.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.models.order import Order
 

--- a/src/lab_manager/services/rag.py
+++ b/src/lab_manager/services/rag.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from litellm import completion
 from sqlalchemy import text
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.config import get_settings
 from lab_manager.services.serialization import serialize_value as _serialize_value

--- a/src/lab_manager/services/search.py
+++ b/src/lab_manager/services/search.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 import logging
 
 import meilisearch
-from sqlalchemy.orm import Session
+from sqlmodel import Session
 
 from lab_manager.config import get_settings
 from lab_manager.services.serialization import serialize_value as _serialize_value


### PR DESCRIPTION
## Summary
- Fix AttributeError: 'Session' object has no attribute 'exec'
- Changed all Session imports from `sqlalchemy.orm` to `sqlmodel`

## Root Cause
Services use `db.exec()` which is a SQLModel Session method, but the database module and routes were importing Session from sqlalchemy.orm.

## Test plan
- [ ] API endpoints return 200 instead of 500
- [ ] Demo deployment works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)