### PR TITLE
fix: import selectinload from sqlalchemy.orm

### DIFF
--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -10,7 +10,8 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field as PydanticField, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, selectinload
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate


### PR DESCRIPTION
## Summary
- Fix import error: `selectinload` must be imported from `sqlalchemy.orm`, not `sqlmodel`
- Update test paths to use `/api/v1/` prefix
- Minor test refactoring

## Test Results
- 842 passed, 146 failed, 27 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)