### PR TITLE
Fix clean-start auth allowlist and product import regression

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -66,6 +66,12 @@ _MAX_USER_LEN = 100
 _AUTH_ALLOWLIST = {
     "/",
     "/api/health",
+    "/api/auth/login",
+    "/api/auth/logout",
+    "/api/auth/me",
+    "/api/setup/status",
+    "/api/setup/complete",
+    "/api/config",
     "/api/v1/auth/login",
     "/api/v1/auth/logout",
     "/api/v1/auth/me",
@@ -370,6 +376,7 @@ def create_app() -> FastAPI:
 
     from fastapi import Body
 
+    @app.post("/api/auth/login", include_in_schema=False)
     @app.post("/api/v1/auth/login")
     @limiter.limit("5/minute")
     def login(
@@ -451,6 +458,7 @@ def create_app() -> FastAPI:
             logger.warning("Failed to record login usage event")
         return response
 
+    @app.get("/api/auth/me", include_in_schema=False)
     @app.get("/api/v1/auth/me")
     def auth_me(request: Request):
         """Return current user info from session cookie. Used by frontend to check auth state."""
@@ -472,6 +480,7 @@ def create_app() -> FastAPI:
             )
         return {"user": {"id": staff["id"], "name": staff["name"]}}
 
+    @app.post("/api/auth/logout", include_in_schema=False)
     @app.post("/api/v1/auth/logout")
     def logout():
         response = JSONResponse({"status": "ok"})
@@ -480,6 +489,7 @@ def create_app() -> FastAPI:
 
     # --- Lab config endpoint (public — frontend reads lab name) ---
 
+    @app.get("/api/config", include_in_schema=False)
     @app.get("/api/v1/config")
     def lab_config():
         cfg = get_settings()
@@ -503,6 +513,7 @@ def create_app() -> FastAPI:
             is not None
         )
 
+    @app.get("/api/setup/status", include_in_schema=False)
     @app.get("/api/v1/setup/status")
     def setup_status():
         """Check if initial setup is needed (no admin user with password exists)."""
@@ -511,6 +522,7 @@ def create_app() -> FastAPI:
         with get_db_session() as db:
             return {"needs_setup": not _admin_exists(db)}
 
+    @app.post("/api/setup/complete", include_in_schema=False)
     @app.post("/api/v1/setup/complete")
     @limiter.limit("3/minute")
     def setup_complete(

--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field as PydanticField, field_validator
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from sqlmodel import Session, selectinload
+from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -185,26 +185,15 @@ def test_admin_auth_requires_admin_password(monkeypatch, auth_engine):
     monkeypatch.setenv("ADMIN_PASSWORD", "")
     get_settings.cache_clear()
 
-    The actual RuntimeError is raised inside admin._make_auth_backend()
-    at startup. We test the Settings validation here directly to avoid
-    cross-test pollution of the get_settings cache.
-    """
-    from lab_manager.config import Settings
+    import lab_manager.database as db_module
 
-    settings_no_pw = Settings(
-        auth_enabled=True,
-        admin_secret_key="test-secret-key-for-signing",
-        admin_password="",
-        api_key="test-api-key-12345",
-    )
+    monkeypatch.setattr(db_module, "_engine", auth_engine)
+    monkeypatch.setattr(db_module, "_session_factory", None)
 
-    # Replicate the exact validation logic from admin._make_auth_backend
-    # to ensure the invariant is enforced without touching global state.
-    assert settings_no_pw.auth_enabled
-    assert not settings_no_pw.admin_password
-    # The RuntimeError in admin.py:140 checks:
-    #   if not settings.admin_password:
-    #       raise RuntimeError("ADMIN_PASSWORD must be set when auth is enabled.")
+    from lab_manager.api.app import create_app
+
+    with pytest.raises(RuntimeError, match="ADMIN_PASSWORD"):
+        create_app()
 
 
 def test_admin_auth_requires_admin_secret_key(monkeypatch, auth_engine):


### PR DESCRIPTION
## Summary
- fix the clean-start import regression by loading `selectinload` from `sqlalchemy.orm` in products routes
- restore backward-compatible public/auth setup paths so first-run endpoints are not blocked by auth middleware
- repair the broken admin-password auth test so the targeted validation suite can run again

## Validation
- `uv run pytest tests/test_auth.py tests/test_deployment.py tests/test_setup.py tests/test_e2e_deployment.py -q`
- Result: `76 passed`
- Real clean Docker first-run smoke check:
  - `GET /api/health` returned ok
  - `GET /api/setup/status` returned `{"needs_setup":true}`
  - `POST /api/setup/complete` returned success
  - `POST /api/auth/login` returned success
  - `GET /api/auth/me` returned the created admin user
