### PR TITLE
Fix release-ready document pipeline and navigation regressions

### DIFF
--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -320,6 +320,8 @@ def upload_document(
     )
     db.add(doc)
     db.flush()
+    # Commit before the background task runs so a fresh session can see the row.
+    db.commit()
     db.refresh(doc)
 
     # Trigger background OCR + extraction
@@ -467,16 +469,17 @@ def review_document(
         ).first()
         if not existing_order and doc.extracted_data:
             _create_order_from_doc(doc, db)
-        # Index all created records in Meilisearch (background)
-        db.flush()
-        background_tasks.add_task(_index_approved_doc, doc.id)
     elif body.action == "reject":
         doc.status = DocumentStatus.rejected
         doc.reviewed_by = body.reviewed_by
         doc.review_notes = body.review_notes
 
     db.flush()
+    # Commit before background indexing so the indexer sees approved state and related records.
+    db.commit()
     db.refresh(doc)
+    if body.action == "approve":
+        background_tasks.add_task(_index_approved_doc, doc.id)
     return doc
 
 

--- a/src/lab_manager/static/index.html
+++ b/src/lab_manager/static/index.html
@@ -123,7 +123,7 @@ tailwind.config = {
 <div id="main-app" class="hidden flex h-screen overflow-hidden">
 
   <!-- ===== SIDEBAR ===== -->
-  <aside class="sidebar w-64 bg-surface-dark border-r border-border-dark flex flex-col flex-shrink-0 hidden md:flex">
+  <aside class="sidebar w-64 bg-surface-dark border-r border-border-dark flex flex-col flex-shrink-0">
     <!-- Sidebar header -->
     <div class="p-5 border-b border-border-dark">
       <div class="flex items-center gap-2 mb-1">

--- a/tests/test_deploy_contracts.py
+++ b/tests/test_deploy_contracts.py
@@ -116,3 +116,27 @@ def test_compose_defaults_to_empty_asset_mounts():
     assert "./docker/empty/devices" in compose
     assert "SCANS_DIR: ${SCANS_DIR:+/app/scans}" in compose
     assert "DEVICES_DIR: ${DEVICES_DIR:+/app/lab-devices}" in compose
+
+
+def test_sidebar_is_not_permanently_hidden():
+    """Desktop navigation should not be hidden by the app's own `.hidden` utility."""
+    html = (REPO_ROOT / "src" / "lab_manager" / "static" / "index.html").read_text(
+        encoding="utf-8"
+    )
+    assert 'aside class="sidebar w-64 bg-surface-dark border-r border-border-dark flex flex-col flex-shrink-0"' in html
+    assert "hidden md:flex" not in html
+
+
+def test_document_background_tasks_run_after_commit():
+    """Guard the commit-before-background-task ordering that real QA depends on."""
+    source = (REPO_ROOT / "src" / "lab_manager" / "api" / "routes" / "documents.py").read_text(
+        encoding="utf-8"
+    )
+    upload_commit = source.index("db.commit()", source.index("status=DocumentStatus.processing"))
+    upload_task = source.index("background_tasks.add_task(_run_extraction, doc.id)")
+    assert upload_commit < upload_task
+
+    approve_block = source.index('if body.action == "approve":')
+    review_commit = source.index("db.commit()", approve_block)
+    review_task = source.index("background_tasks.add_task(_index_approved_doc, doc.id)")
+    assert review_commit < review_task


### PR DESCRIPTION
## Summary
- commit uploaded documents before starting background extraction so real OCR/VLM tasks can see them
- commit approved review state before background indexing so search sees fresh document status and related records
- unhide the desktop sidebar so users can actually access all major pages
- add regression tests locking the commit-before-background-task ordering and sidebar visibility contract

## Automated validation
- `uv run pytest tests/test_deploy_contracts.py tests/test_upload.py tests/test_pipeline_e2e.py tests/test_rag_execution.py tests/test_search_service.py -q`
- Result: `69 passed, 7 skipped`

## Real QA validation
Using real user personas and a real noisy shipping-label image derived from `labdemo-docs` with NVIDIA-only models:
- PI / PhD / Postdoc accounts all logged in successfully via browser
- Dashboard / Documents / Review Queue / Inventory / Orders / Upload pages all opened successfully
- Mobile view loaded successfully
- Real noisy shipping-label upload succeeded
- OCR + extraction completed with NVIDIA-only models
- Review Queue loaded the real document and buttons were exercised
- Search returned the uploaded/approved ThermoFisher document and vendor
- Ask AI answered from the real uploaded document data

## Notes
`labdemo-docs` was used only for local private QA, not committed into test fixtures or CI.