### PR TITLE
CI: run release gates on self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   frontend:
     name: Frontend (lint, build, test)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 15
 
     steps:
@@ -49,7 +49,7 @@ jobs:
 
   lint:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 15
 
     steps:
@@ -75,7 +75,7 @@ jobs:
 
   typecheck:
     name: typecheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 15
 
     steps:
@@ -101,7 +101,7 @@ jobs:
 
   test:
     name: test (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 25
     strategy:
       fail-fast: false
@@ -116,7 +116,7 @@ jobs:
           POSTGRES_PASSWORD: labmanager
           POSTGRES_DB: labmanager
         ports:
-          - 5432:5432
+          - 15433:5432
         options: >-
           --health-cmd="pg_isready -U labmanager"
           --health-interval=10s
@@ -126,13 +126,13 @@ jobs:
       meilisearch:
         image: getmeili/meilisearch:v1.12
         ports:
-          - 7700:7700
+          - 17701:7700
         env:
           MEILI_ENV: development
 
     env:
-      DATABASE_URL: postgresql+psycopg://labmanager:labmanager@localhost:5432/labmanager
-      MEILISEARCH_URL: http://localhost:7700
+      DATABASE_URL: postgresql+psycopg://labmanager:labmanager@localhost:15433/labmanager
+      MEILISEARCH_URL: http://localhost:17701
       AUTH_ENABLED: "false"
 
     steps:
@@ -167,7 +167,7 @@ jobs:
 
   package:
     name: package
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 15
     needs:
       - lint

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   dependency-audit:
     name: dependency-audit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 20
 
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   bandit:
     name: bandit-sast
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 15
 
     steps:
@@ -80,7 +80,7 @@ jobs:
 
   codeql:
     name: codeql
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 30
     if: github.event_name != 'pull_request'
     continue-on-error: true  # GHAS required; free once repo is public
@@ -103,7 +103,7 @@ jobs:
 
   secrets-scan:
     name: secrets-scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, ubuntu]
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary
- switch CI jobs to the org self-hosted runner (`labclaw-runner-01`)
- switch Security jobs to the org self-hosted runner as well
- remap PostgreSQL / Meilisearch service ports in the test matrix to avoid collisions on the runner host

## Why
GitHub-hosted jobs are currently not starting due to billing / spending-limit issues, so CI cannot act as a release gate even when the product itself is passing real validation. This change restores an actual runnable CI gate.

## Validation
- workflow YAML parses locally
- org runner exists and is online with labels: `self-hosted`, `Linux`, `X64`, `ubuntu`
