### PR TITLE
fix(deploy): preserve HTTPS redirects behind Cloudflare tunnel

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -3,7 +3,9 @@
 }
 
 :80 {
-    reverse_proxy app:8000
+    reverse_proxy app:8000 {
+        header_up X-Forwarded-Proto https
+    }
     encode gzip
 
     header {

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -22,4 +22,4 @@ echo "[entrypoint] Running database migrations..."
 /app/.venv/bin/alembic upgrade head
 
 echo "[entrypoint] Starting application..."
-exec /app/.venv/bin/uvicorn lab_manager.api.app:create_app --factory --host 0.0.0.0 --port 8000
+exec /app/.venv/bin/uvicorn lab_manager.api.app:create_app --factory --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips="*"


### PR DESCRIPTION
## Summary
- align deploy branch to latest `release/0.1.6-prep`
- set `X-Forwarded-Proto: https` in Caddy reverse proxy to avoid mixed-content redirect targets
- run uvicorn with proxy header trust (`--proxy-headers --forwarded-allow-ips=*`) so framework-generated redirects keep HTTPS

## Verification
- `https://demo.labclaw.org/` returns 200
- `/api/v1/vendors?page=1&page_size=100` redirects to HTTPS (not HTTP)
- gstack browser load shows dashboard API calls succeeding (no CSP/mixed-content fetch failures)
