### PR TITLE
ci(lab-manager): add conventional-pre-commit and gitleaks hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
         args: ["--maxkb=51200"]
       - id: no-commit-to-branch
         args: ["--branch", "main"]
+      - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.2
@@ -25,3 +26,15 @@ repos:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
         exclude: uv\.lock
+
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## Summary
- Add conventional-pre-commit hook for commit message enforcement
- Add gitleaks hook for secrets scanning (complements existing detect-secrets)
- Add check-merge-conflict hook

## Changes
- `.pre-commit-config.yaml` — updated (added 3 hooks)

## Checklist
- [x] No workflow changes (already gold standard)
- [x] Conventional commit enforcement added
- [x] Secrets scanning via gitleaks pre-commit (detect-secrets retained)
- [x] check-merge-conflict added

🤖 Generated with [Claude Code](https://claude.com/claude-code)