### PR TITLE
fix(lint): remove unused variable in litellm_client

### DIFF
--- a/src/lab_manager/services/litellm_client.py
+++ b/src/lab_manager/services/litellm_client.py
@@ -200,7 +200,7 @@ def create_completion(
         >>> print(response.choices[0].message.content)
     """
     # Load config if available (for routing/fallbacks)
-    config = load_litellm_config()
+    load_litellm_config()
 
     # Get client params (API keys, base URLs)
     client_params = get_client_params(model)


### PR DESCRIPTION
## Summary
- Remove unused `config` variable in `litellm_client.py:203` caught by ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)