### PR TITLE
fix(security): pin litellm<=1.82.6 — supply chain attack

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
   "itsdangerous>=2.2.0",
   "structlog>=24.0.0",
   "slowapi>=0.1.9",
-  "litellm>=1.82.4",
+  "litellm>=1.82.4,<=1.82.6",  # SECURITY: 1.82.7+ compromised (supply chain attack 2026-03-24)
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- Pin `litellm<=1.82.6` to block compromised versions 1.82.7 and 1.82.8
- Versions 1.82.7+1.82.8 contain credential-stealing backdoor via Trivy CI/CD compromise
- Our installed version (1.82.4) is verified safe — no malicious `.pth` files found

## Context
- [GitHub Issue #24518](https://github.com/BerriAI/litellm/issues/24518) — full timeline
- [The Hacker News](https://thehackernews.com/2026/03/teampcp-backdoors-litellm-versions.html) — attack analysis
- Compromised versions yanked from PyPI but upper bound pin prevents future risk

## Test plan
- [x] Verified all installed environments are on 1.82.4 (safe)
- [x] No `litellm_init.pth` malware found in any venv
- [x] All `proxy_server.py` hashes match clean version
- [ ] CI passes with pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)