### PR TITLE
refactor(ui): differentiate Analytics from Dashboard

### DIFF
--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import {
-  BarChart3, FileText, Package, Store, CheckCircle, Clock,
-  TrendingUp, Users, Beaker, Wrench, Box,
+  BarChart3, FileText, Package, Store, Clock,
+  TrendingUp, AlertTriangle, Beaker, Wrench, Box, Brain,
+  Activity, ShieldCheck, PieChart, Users, Search,
 } from 'lucide-react'
 import { analytics, documents as docApi, inventory as invApi } from '@/lib/api'
 import type { DashboardStats, DocumentStats, Document, InventoryItem } from '@/lib/api'
@@ -15,13 +16,13 @@ interface AnalyticsPageProps {
 type TabValue = 'overview' | 'vendors' | 'documents' | 'inventory'
 
 const TABS: { readonly value: TabValue; readonly label: string; readonly icon: typeof BarChart3 }[] = [
-  { value: 'overview', label: 'Overview', icon: TrendingUp },
+  { value: 'overview', label: 'Lab Intelligence', icon: Brain },
   { value: 'vendors', label: 'Vendors', icon: Store },
   { value: 'documents', label: 'Documents', icon: FileText },
   { value: 'inventory', label: 'Inventory', icon: Package },
 ]
 
-// Vendor category mapping (from standalone analytics)
+// Vendor category mapping
 const REAGENT_VENDORS = new Set([
   'Sigma-Aldrich', 'Millipore Sigma', 'EMD Millipore Corporation', 'MilliporeSigma Corporation',
   'SIGMA-ALDRICH', 'Sigma Aldrich', 'Sigma Aldrich, Inc.', 'Sigma-Aldrich, Inc.',
@@ -48,22 +49,6 @@ const EQUIPMENT_VENDORS = new Set([
   'B&H Photo & Video', 'Iwai North America Inc.', 'DigiKey', 'DigiKey Electronics', 'Digikay', 'Newark',
 ])
 
-const DOC_TYPE_LABELS: Record<string, string> = {
-  packing_list: 'Packing Lists',
-  invoice: 'Invoices',
-  shipping_label: 'Shipping Labels',
-  certificate_of_analysis: 'Certificates of Analysis',
-  other: 'Other',
-  mta: 'Material Transfer Agreements',
-  receipt: 'Receipts',
-  null: 'Unclassified',
-}
-
-const CHART_COLORS = [
-  'bg-primary', 'bg-emerald-500', 'bg-sky-500', 'bg-amber-500',
-  'bg-rose-500', 'bg-teal-500', 'bg-violet-500', 'bg-orange-500',
-]
-
 const CONFIDENCE_BUCKETS = [
   { label: '0-50%', range: [0, 0.5] as const, color: 'bg-red-500' },
   { label: '50-60%', range: [0.5, 0.6] as const, color: 'bg-orange-500' },
@@ -76,19 +61,18 @@ const CONFIDENCE_BUCKETS = [
 ]
 
 // ----------------------------------------------------------------
-// Stat Card (reused across tabs)
+// Insight banner — bold headline + supporting text
 // ----------------------------------------------------------------
-function StatCard({ label, value, sub, icon: Icon }: {
-  label: string; value: string | number; sub: string; icon: typeof BarChart3
-}) {
+function Insight({ text, variant = 'info' }: { text: string; variant?: 'info' | 'warn' | 'good' | 'bad' }) {
+  const colors = {
+    info: 'bg-primary/5 border-primary/20 text-primary',
+    warn: 'bg-amber-50 dark:bg-amber-500/10 border-amber-200 dark:border-amber-500/20 text-amber-700 dark:text-amber-400',
+    good: 'bg-emerald-50 dark:bg-emerald-500/10 border-emerald-200 dark:border-emerald-500/20 text-emerald-700 dark:text-emerald-400',
+    bad: 'bg-red-50 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-700 dark:text-red-400',
+  }
   return (
-    <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-      <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
-        <span className="text-[11px] font-bold uppercase tracking-wider">{label}</span>
-        <Icon className="size-5 opacity-50" />
-      </div>
-      <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{value}</div>
-      <div className="text-[11px] text-[var(--muted-foreground)] font-medium">{sub}</div>
+    <div className={`text-sm font-semibold px-4 py-2.5 rounded-lg border ${colors[variant]}`}>
+      {text}
     </div>
   )
 }
@@ -96,8 +80,8 @@ function StatCard({ label, value, sub, icon: Icon }: {
 // ----------------------------------------------------------------
 // Horizontal bar row
 // ----------------------------------------------------------------
-function BarRow({ label, count, max, index }: {
-  label: string; count: number; max: number; index: number
+function BarRow({ label, count, max, index, suffix }: {
+  label: string; count: number; max: number; index: number; suffix?: string
 }) {
   const pct = max > 0 ? Math.round((count / max) * 100) : 0
   const opacities = ['', '/80', '/60', '/40', '/20']
@@ -106,7 +90,7 @@ function BarRow({ label, count, max, index }: {
     <div className="space-y-1.5">
       <div className="flex justify-between items-end">
         <span className="text-sm text-[var(--foreground)] font-semibold truncate mr-2">{label}</span>
-        <span className="text-xs text-[var(--muted-foreground)] font-mono shrink-0">{count}</span>
+        <span className="text-xs text-[var(--muted-foreground)] font-mono shrink-0">{count}{suffix ? ` ${suffix}` : ''}</span>
       </div>
       <div className="h-2 w-full bg-[var(--card)] rounded-full overflow-hidden border border-primary/5">
         <div
@@ -119,10 +103,10 @@ function BarRow({ label, count, max, index }: {
 }
 
 // ================================================================
-// OVERVIEW TAB
+// OVERVIEW TAB — "Lab Intelligence"
+// No duplicate stats cards. Unique insights only.
 // ================================================================
-function OverviewTab({ stats, docs, docStats }: {
-  stats: DashboardStats | undefined
+function OverviewTab({ docs, docStats }: {
   docs: Document[]
   docStats: DocumentStats | undefined
 }) {
@@ -130,98 +114,209 @@ function OverviewTab({ stats, docs, docStats }: {
     () => docs.filter(d => d.extraction_confidence != null).map(d => d.extraction_confidence!),
     [docs],
   )
+  const totalDocs = docStats?.total_documents ?? docs.length
   const highConf = confidences.filter(c => c > 0.8).length
   const accuracy = confidences.length > 0 ? ((highConf / confidences.length) * 100).toFixed(1) : '0'
+  const meanConf = confidences.length > 0
+    ? (confidences.reduce((a, b) => a + b, 0) / confidences.length * 100).toFixed(1)
+    : '0'
 
-  const vendorSet = useMemo(() => new Set(docs.map(d => d.vendor_name).filter(Boolean)), [docs])
+  // Processing status breakdown
+  const statusMap = docStats?.by_status ?? {}
+  const approvedCount = statusMap['approved'] ?? 0
+  const reviewCount = statusMap['needs_review'] ?? 0
+  const rejectedCount = statusMap['rejected'] ?? 0
+  const statusTotal = approvedCount + reviewCount + rejectedCount
+  const approvedPct = statusTotal > 0 ? Math.round((approvedCount / statusTotal) * 100) : 0
+  const reviewPct = statusTotal > 0 ? Math.round((reviewCount / statusTotal) * 100) : 0
+  const rejectedPct = statusTotal > 0 ? Math.round((rejectedCount / statusTotal) * 100) : 0
 
-  let totalItems = 0
-  for (const d of docs) {
-    if (d.extracted_data?.items) totalItems += d.extracted_data.items.length
-  }
-
-  const pending = docStats?.by_status?.needs_review ?? stats?.documents_pending_review ?? 0
-
-  // Top 5 vendors for quick view
-  const vendorTop5 = useMemo(() => {
-    const counts: Record<string, number> = {}
+  // Avg confidence by vendor (find lowest)
+  const vendorConfidence = useMemo(() => {
+    const map: Record<string, { sum: number; count: number }> = {}
     for (const d of docs) {
-      const v = d.vendor_name ?? 'Unknown'
-      counts[v] = (counts[v] ?? 0) + 1
+      const v = d.vendor_name
+      const c = d.extraction_confidence
+      if (v && c != null) {
+        if (!map[v]) map[v] = { sum: 0, count: 0 }
+        map[v].sum += c
+        map[v].count += 1
+      }
     }
-    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 5)
-    const max = sorted[0]?.[1] ?? 1
-    return { items: sorted, max }
+    return Object.entries(map)
+      .map(([name, { sum, count }]) => ({ name, avg: sum / count, count }))
+      .filter(v => v.count >= 2) // need at least 2 docs for meaningful average
+      .sort((a, b) => a.avg - b.avg) // lowest first
   }, [docs])
 
-  // Top 4 doc types
-  const docTypeTop4 = useMemo(() => {
-    const typeMap = docStats?.by_type ?? {}
-    const entries = Object.entries(typeMap).sort((a, b) => b[1] - a[1]).slice(0, 4)
-    const max = entries[0]?.[1] ?? 1
-    return { items: entries, max }
-  }, [docStats])
+  const worstVendor = vendorConfidence[0]
+  const bestVendor = vendorConfidence.length > 0 ? vendorConfidence[vendorConfidence.length - 1] : undefined
+
+  // Oldest pending review
+  const oldestPending = useMemo(() => {
+    const pending = docs
+      .filter(d => d.status === 'needs_review' && d.created_at)
+      .sort((a, b) => (a.created_at ?? '').localeCompare(b.created_at ?? ''))
+    return pending[0]
+  }, [docs])
+
+  const oldestDaysAgo = oldestPending?.created_at
+    ? Math.floor((Date.now() - new Date(oldestPending.created_at).getTime()) / (1000 * 60 * 60 * 24))
+    : 0
+
+  // Confidence sparkline — mini histogram for inline display
+  const sparkline = useMemo(() => {
+    return CONFIDENCE_BUCKETS.map(bucket => ({
+      ...bucket,
+      count: confidences.filter(c => c >= bucket.range[0] && c < bucket.range[1]).length,
+    }))
+  }, [confidences])
+  const sparkMax = Math.max(...sparkline.map(b => b.count), 1)
 
   return (
-    <div className="space-y-8">
-      {/* Stats bar */}
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <StatCard label="Documents Processed" value={docStats?.total_documents ?? docs.length} sub="scanned & extracted" icon={FileText} />
-        <StatCard label="Unique Vendors" value={vendorSet.size} sub="suppliers identified" icon={Store} />
-        <StatCard label="Items Tracked" value={totalItems} sub="catalog items extracted" icon={Package} />
-        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider">AI Accuracy</span>
-            <CheckCircle className="size-5 opacity-50" />
-          </div>
-          <div className="text-3xl font-bold text-primary tracking-tight">{accuracy}%</div>
-          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">confidence &gt; 0.8</div>
-        </div>
-        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
-          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
-            <span className="text-[11px] font-bold uppercase tracking-wider">Pending Review</span>
-            <Clock className="size-5 opacity-50" />
-          </div>
-          <div className="text-3xl font-bold text-amber-600 tracking-tight">{pending}</div>
-          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">awaiting human QA</div>
-        </div>
+    <div className="space-y-6">
+      {/* Headline insights */}
+      <div className="space-y-2">
+        <Insight
+          text={`${accuracy}% of ${totalDocs} documents extracted with >80% confidence — ${
+            parseFloat(accuracy) >= 90 ? 'your pipeline is reliable' : 'review low-confidence documents below'
+          }`}
+          variant={parseFloat(accuracy) >= 90 ? 'good' : 'warn'}
+        />
+        {reviewCount > 0 && (
+          <Insight
+            text={`${reviewCount} document${reviewCount > 1 ? 's' : ''} pending review${
+              oldestDaysAgo > 0 ? ` — oldest is from ${oldestDaysAgo} day${oldestDaysAgo > 1 ? 's' : ''} ago` : ''
+            }`}
+            variant={oldestDaysAgo > 7 ? 'bad' : 'warn'}
+          />
+        )}
+        {worstVendor && (
+          <Insight
+            text={`${worstVendor.name} has the lowest AI accuracy (${(worstVendor.avg * 100).toFixed(0)}%) across ${worstVendor.count} docs — consider manual review`}
+            variant={worstVendor.avg < 0.8 ? 'bad' : 'warn'}
+          />
+        )}
       </div>
 
-      {/* Charts row */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Top vendors quick */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* AI Performance card */}
         <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-[var(--foreground)] text-base font-bold flex items-center gap-2">
-              <BarChart3 className="size-5 text-primary" />
-              Top Vendors
-            </h3>
-            <span className="text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-widest">by documents</span>
+          <div className="flex items-center gap-2 mb-4">
+            <ShieldCheck className="size-5 text-primary" />
+            <h3 className="text-[var(--foreground)] text-base font-bold">AI Performance</h3>
           </div>
           <div className="space-y-4">
-            {vendorTop5.items.map(([name, count], i) => (
-              <BarRow key={name} label={name} count={count} max={vendorTop5.max} index={i} />
-            ))}
-            {vendorTop5.items.length === 0 && (
-              <p className="text-sm text-[var(--muted-foreground)] py-4">No vendor data yet</p>
+            <div>
+              <div className="text-4xl font-bold text-primary tracking-tight">{accuracy}%</div>
+              <div className="text-xs text-[var(--muted-foreground)] mt-1">accuracy across {totalDocs} documents (confidence &gt; 0.8)</div>
+            </div>
+            <div className="flex justify-between items-center text-sm border-t border-primary/10 pt-3">
+              <span className="text-[var(--muted-foreground)]">Mean confidence</span>
+              <span className="font-semibold text-[var(--foreground)]">{meanConf}%</span>
+            </div>
+            {bestVendor && (
+              <div className="flex justify-between items-center text-sm">
+                <span className="text-[var(--muted-foreground)]">Best vendor accuracy</span>
+                <span className="font-semibold text-emerald-600">{bestVendor.name} ({(bestVendor.avg * 100).toFixed(0)}%)</span>
+              </div>
             )}
+            {/* Mini sparkline */}
+            <div className="border-t border-primary/10 pt-3">
+              <h4 className="text-[10px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider mb-2">Confidence Distribution</h4>
+              <div className="flex items-end gap-1 h-12">
+                {sparkline.map(bucket => (
+                  <div key={bucket.label} className="flex-1 flex flex-col items-center gap-0.5">
+                    <div
+                      className={`w-full ${bucket.color} rounded-t transition-all duration-500`}
+                      style={{ height: `${sparkMax > 0 ? (bucket.count / sparkMax) * 100 : 0}%`, minHeight: bucket.count > 0 ? '2px' : '0' }}
+                    />
+                  </div>
+                ))}
+              </div>
+              <div className="flex gap-1 mt-0.5">
+                {sparkline.map(bucket => (
+                  <div key={bucket.label} className="flex-1 text-center text-[8px] text-[var(--muted-foreground)]">
+                    {bucket.count > 0 ? bucket.count : ''}
+                  </div>
+                ))}
+              </div>
+            </div>
           </div>
         </div>
 
-        {/* Doc types quick */}
+        {/* Processing Status — pie-like breakdown */}
         <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
-          <div className="flex items-center justify-between mb-6">
-            <h3 className="text-[var(--foreground)] text-base font-bold flex items-center gap-2">
-              <FileText className="size-5 text-primary" />
-              Document Types
-            </h3>
+          <div className="flex items-center gap-2 mb-4">
+            <PieChart className="size-5 text-primary" />
+            <h3 className="text-[var(--foreground)] text-base font-bold">Processing Status</h3>
           </div>
-          <div className="space-y-4">
-            {docTypeTop4.items.map(([type, count], i) => (
-              <BarRow key={type} label={DOC_TYPE_LABELS[type] ?? formatEnum(type)} count={count} max={docTypeTop4.max} index={i} />
-            ))}
-            {docTypeTop4.items.length === 0 && (
-              <p className="text-sm text-[var(--muted-foreground)] py-4">No document type data yet</p>
+          {statusTotal > 0 ? (
+            <div className="space-y-5">
+              {/* Visual bar */}
+              <div className="h-4 w-full rounded-full overflow-hidden flex">
+                {approvedPct > 0 && (
+                  <div className="h-full bg-emerald-500 transition-all duration-500" style={{ width: `${approvedPct}%` }} />
+                )}
+                {reviewPct > 0 && (
+                  <div className="h-full bg-amber-500 transition-all duration-500" style={{ width: `${reviewPct}%` }} />
+                )}
+                {rejectedPct > 0 && (
+                  <div className="h-full bg-red-500 transition-all duration-500" style={{ width: `${rejectedPct}%` }} />
+                )}
+              </div>
+              <div className="space-y-3">
+                <div className="flex items-center justify-between text-sm">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
+                    <span className="text-[var(--foreground)] font-medium">Approved</span>
+                  </div>
+                  <span className="font-semibold text-[var(--foreground)]">{approvedCount} <span className="text-[var(--muted-foreground)] font-normal text-xs">({approvedPct}%)</span></span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2.5 h-2.5 rounded-full bg-amber-500" />
+                    <span className="text-[var(--foreground)] font-medium">Needs Review</span>
+                  </div>
+                  <span className="font-semibold text-[var(--foreground)]">{reviewCount} <span className="text-[var(--muted-foreground)] font-normal text-xs">({reviewPct}%)</span></span>
+                </div>
+                <div className="flex items-center justify-between text-sm">
+                  <div className="flex items-center gap-2">
+                    <div className="w-2.5 h-2.5 rounded-full bg-red-500" />
+                    <span className="text-[var(--foreground)] font-medium">Rejected</span>
+                  </div>
+                  <span className="font-semibold text-[var(--foreground)]">{rejectedCount} <span className="text-[var(--muted-foreground)] font-normal text-xs">({rejectedPct}%)</span></span>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-[var(--muted-foreground)] py-4">No status data yet</p>
+          )}
+        </div>
+
+        {/* Extraction Quality — confidence by vendor */}
+        <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
+          <div className="flex items-center gap-2 mb-4">
+            <Activity className="size-5 text-primary" />
+            <h3 className="text-[var(--foreground)] text-base font-bold">Extraction Quality</h3>
+          </div>
+          <p className="text-xs text-[var(--muted-foreground)] mb-4">Avg confidence by vendor (lowest first — needs attention)</p>
+          <div className="space-y-3">
+            {vendorConfidence.slice(0, 8).map((v, i) => {
+              const pct = (v.avg * 100).toFixed(0)
+              const color = v.avg >= 0.9 ? 'text-emerald-600' : v.avg >= 0.8 ? 'text-amber-600' : 'text-red-500'
+              return (
+                <div key={v.name} className="flex items-center justify-between text-sm">
+                  <span className="text-[var(--foreground)] truncate mr-2 font-medium">{i + 1}. {v.name}</span>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <span className={`font-mono font-semibold ${color}`}>{pct}%</span>
+                    <span className="text-[10px] text-[var(--muted-foreground)]">({v.count} docs)</span>
+                  </div>
+                </div>
+              )
+            })}
+            {vendorConfidence.length === 0 && (
+              <p className="text-sm text-[var(--muted-foreground)] py-4">Need at least 2 docs per vendor for analysis</p>
             )}
           </div>
         </div>
@@ -231,7 +326,7 @@ function OverviewTab({ stats, docs, docStats }: {
 }
 
 // ================================================================
-// VENDORS TAB
+// VENDORS TAB — enhanced with diversity insight
 // ================================================================
 function VendorsTab({ docs }: { docs: Document[] }) {
   const [filter, setFilter] = useState<'all' | 'reagents' | 'equipment' | 'supplies'>('all')
@@ -267,6 +362,15 @@ function VendorsTab({ docs }: { docs: Document[] }) {
     supplies: vendorData.filter(v => v.category === 'supplies').length,
   }), [vendorData])
 
+  // Vendor diversity analysis
+  const diversity = useMemo(() => {
+    const totalDocs = vendorData.reduce((s, v) => s + v.count, 0)
+    const top3Docs = vendorData.slice(0, 3).reduce((s, v) => s + v.count, 0)
+    const top3Pct = totalDocs > 0 ? Math.round((top3Docs / totalDocs) * 100) : 0
+    const top3Names = vendorData.slice(0, 3).map(v => v.name)
+    return { totalVendors: vendorData.length, totalDocs, top3Docs, top3Pct, top3Names }
+  }, [vendorData])
+
   const filterButtons: { key: typeof filter; label: string; icon: typeof Beaker }[] = [
     { key: 'all', label: 'All', icon: Users },
     { key: 'reagents', label: 'Reagents', icon: Beaker },
@@ -275,12 +379,41 @@ function VendorsTab({ docs }: { docs: Document[] }) {
   ]
 
   return (
-    <div className="space-y-8">
-      {/* Category stats */}
-      <div className="grid grid-cols-3 gap-4">
-        <StatCard label="Reagent Vendors" value={categoryCounts.reagents} sub="bio & chem suppliers" icon={Beaker} />
-        <StatCard label="Equipment Vendors" value={categoryCounts.equipment} sub="instruments & devices" icon={Wrench} />
-        <StatCard label="General Supplies" value={categoryCounts.supplies} sub="consumables & other" icon={Box} />
+    <div className="space-y-6">
+      {/* Headline insights */}
+      <div className="space-y-2">
+        <Insight
+          text={`Your top 3 vendors (${diversity.top3Names.join(', ')}) account for ${diversity.top3Pct}% of all documents — ${
+            diversity.top3Pct > 50 ? 'high supplier concentration risk' : 'healthy vendor diversity'
+          }`}
+          variant={diversity.top3Pct > 50 ? 'warn' : 'good'}
+        />
+        <Insight
+          text={`${diversity.totalVendors} unique vendors across ${diversity.totalDocs} documents — ${categoryCounts.reagents} reagent, ${categoryCounts.equipment} equipment, ${categoryCounts.supplies} general supply`}
+          variant="info"
+        />
+      </div>
+
+      {/* Vendor Diversity card */}
+      <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
+        <div className="flex items-center gap-2 mb-4">
+          <TrendingUp className="size-5 text-primary" />
+          <h3 className="text-[var(--foreground)] text-base font-bold">Vendor Concentration</h3>
+        </div>
+        <div className="grid grid-cols-3 gap-4">
+          <div className="text-center p-4 bg-[var(--background)] rounded-lg">
+            <div className="text-2xl font-bold text-[var(--foreground)]">{diversity.totalVendors}</div>
+            <div className="text-[11px] text-[var(--muted-foreground)] font-medium mt-1">Total Vendors</div>
+          </div>
+          <div className="text-center p-4 bg-[var(--background)] rounded-lg">
+            <div className={`text-2xl font-bold ${diversity.top3Pct > 50 ? 'text-amber-600' : 'text-emerald-600'}`}>{diversity.top3Pct}%</div>
+            <div className="text-[11px] text-[var(--muted-foreground)] font-medium mt-1">Top 3 Concentration</div>
+          </div>
+          <div className="text-center p-4 bg-[var(--background)] rounded-lg">
+            <div className="text-2xl font-bold text-[var(--foreground)]">{diversity.totalDocs}</div>
+            <div className="text-[11px] text-[var(--muted-foreground)] font-medium mt-1">Total Documents</div>
+          </div>
+        </div>
       </div>
 
       {/* Top 20 */}
@@ -294,7 +427,7 @@ function VendorsTab({ docs }: { docs: Document[] }) {
         </div>
         <div className="space-y-3">
           {top20.map(({ name, count }, i) => (
-            <BarRow key={name} label={name} count={count} max={max} index={Math.min(i, 4)} />
+            <BarRow key={name} label={name} count={count} max={max} index={Math.min(i, 4)} suffix="docs" />
           ))}
         </div>
       </div>
@@ -342,9 +475,10 @@ function VendorsTab({ docs }: { docs: Document[] }) {
 }
 
 // ================================================================
-// DOCUMENTS TAB
+// DOCUMENTS TAB — confidence histogram + problem docs + extraction log
+// No doc type pie (Dashboard has it)
 // ================================================================
-function DocumentsTab({ docs, docStats }: { docs: Document[]; docStats: DocumentStats | undefined }) {
+function DocumentsTab({ docs }: { docs: Document[] }) {
   const confidences = useMemo(
     () => docs.filter(d => d.extraction_confidence != null).map(d => d.extraction_confidence!),
     [docs],
@@ -363,15 +497,17 @@ function DocumentsTab({ docs, docStats }: { docs: Document[]; docStats: Document
     ? (confidences.reduce((a, b) => a + b, 0) / confidences.length * 100).toFixed(1)
     : '0'
   const highConfCount = confidences.filter(c => c >= 0.9).length
+  const lowConfCount = confidences.filter(c => c < 0.8).length
 
-  // Doc type breakdown (full)
-  const typeEntries = useMemo(() => {
-    const typeMap = docStats?.by_type ?? {}
-    return Object.entries(typeMap).sort((a, b) => b[1] - a[1])
-  }, [docStats])
-  const typeTotal = typeEntries.reduce((s, e) => s + e[1], 0)
+  // Problem documents — lowest confidence
+  const problemDocs = useMemo(() => {
+    return [...docs]
+      .filter(d => d.extraction_confidence != null && d.extraction_confidence < 0.8)
+      .sort((a, b) => (a.extraction_confidence ?? 0) - (b.extraction_confidence ?? 0))
+      .slice(0, 15)
+  }, [docs])
 
-  // Recent 20 docs
+  // Recent extraction log
   const recentDocs = useMemo(() => {
     return [...docs]
       .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
@@ -379,129 +515,142 @@ function DocumentsTab({ docs, docStats }: { docs: Document[]; docStats: Document
   }, [docs])
 
   return (
-    <div className="space-y-8">
-      {/* Doc type breakdown + confidence side by side */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Document type breakdown */}
-        <div className="lg:col-span-2 bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
-          <div className="mb-6">
-            <h3 className="text-[var(--foreground)] text-base font-bold flex items-center gap-2">
-              <FileText className="size-5 text-primary" />
-              Document Types
-            </h3>
-            <p className="text-xs text-[var(--muted-foreground)] mt-0.5">Breakdown of all processed documents</p>
-          </div>
-          <div className="space-y-3">
-            {typeEntries.map(([type, count], i) => {
-              const pct = typeTotal > 0 ? ((count / typeTotal) * 100).toFixed(0) : '0'
-              return (
-                <div key={type} className="flex items-center gap-3">
-                  <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${CHART_COLORS[i % CHART_COLORS.length]}`} />
-                  <span className="text-sm text-[var(--foreground)] font-medium flex-1 truncate">
-                    {DOC_TYPE_LABELS[type] ?? formatEnum(type)}
-                  </span>
-                  <span className="text-sm font-semibold text-[var(--foreground)]">{count}</span>
-                  <span className="text-xs text-[var(--muted-foreground)] w-10 text-right">{pct}%</span>
-                </div>
-              )
-            })}
-          </div>
-        </div>
+    <div className="space-y-6">
+      {/* Headline insights */}
+      <div className="space-y-2">
+        <Insight
+          text={`${highConfCount} of ${confidences.length} documents have >90% confidence (mean: ${meanConf}%) — ${
+            parseFloat(meanConf) >= 85 ? 'extraction quality is strong' : 'consider reprocessing low-confidence docs'
+          }`}
+          variant={parseFloat(meanConf) >= 85 ? 'good' : 'warn'}
+        />
+        {lowConfCount > 0 && (
+          <Insight
+            text={`${lowConfCount} document${lowConfCount > 1 ? 's' : ''} below 80% confidence — flagged for review below`}
+            variant="bad"
+          />
+        )}
+      </div>
 
-        {/* AI confidence summary */}
-        <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
-          <div className="mb-6">
-            <h3 className="text-[var(--foreground)] text-base font-bold">AI Performance</h3>
-            <p className="text-xs text-[var(--muted-foreground)] mt-0.5">Extraction confidence metrics</p>
-          </div>
-          <div className="space-y-4">
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[var(--muted-foreground)]">Mean confidence</span>
-              <span className="font-semibold text-[var(--foreground)]">{meanConf}%</span>
-            </div>
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[var(--muted-foreground)]">Docs with &gt; 90% conf</span>
-              <span className="font-semibold text-emerald-600">{highConfCount} / {confidences.length}</span>
-            </div>
-            <div className="flex justify-between items-center text-sm">
-              <span className="text-[var(--muted-foreground)]">Extraction model</span>
-              <span className="font-mono text-xs text-[var(--muted-foreground)]">LLaMA 3.2 90B</span>
-            </div>
-            <div className="border-t border-primary/10 pt-4 mt-2">
-              <h4 className="text-xs font-bold text-[var(--muted-foreground)] uppercase tracking-wider mb-3">Confidence Distribution</h4>
-              <div className="space-y-2">
-                {histogram.map(bucket => (
-                  <div key={bucket.label} className="flex items-center gap-2">
-                    <span className="text-[10px] text-[var(--muted-foreground)] w-12 shrink-0">{bucket.label}</span>
-                    <div className="flex-1 h-3 bg-[var(--background)] rounded-full overflow-hidden">
-                      <div
-                        className={`h-full ${bucket.color} rounded-full transition-all duration-500`}
-                        style={{ width: `${histMax > 0 ? (bucket.count / histMax) * 100 : 0}%` }}
-                      />
-                    </div>
-                    <span className="text-[10px] font-mono text-[var(--muted-foreground)] w-6 text-right">{bucket.count}</span>
-                  </div>
-                ))}
+      {/* Confidence histogram */}
+      <div className="bg-[var(--card)] border border-primary/10 rounded-xl p-6 shadow-sm">
+        <div className="flex items-center gap-2 mb-6">
+          <BarChart3 className="size-5 text-primary" />
+          <h3 className="text-[var(--foreground)] text-base font-bold">Confidence Distribution</h3>
+          <span className="text-xs text-[var(--muted-foreground)] ml-auto">{confidences.length} documents with confidence scores</span>
+        </div>
+        <div className="space-y-2.5">
+          {histogram.map(bucket => (
+            <div key={bucket.label} className="flex items-center gap-3">
+              <span className="text-xs text-[var(--muted-foreground)] w-14 shrink-0 font-mono">{bucket.label}</span>
+              <div className="flex-1 h-5 bg-[var(--background)] rounded-full overflow-hidden">
+                <div
+                  className={`h-full ${bucket.color} rounded-full transition-all duration-500`}
+                  style={{ width: `${histMax > 0 ? (bucket.count / histMax) * 100 : 0}%` }}
+                />
               </div>
+              <span className="text-xs font-mono text-[var(--muted-foreground)] w-8 text-right font-semibold">{bucket.count}</span>
             </div>
-          </div>
+          ))}
         </div>
       </div>
 
-      {/* Recent documents table */}
-      <div className="bg-[var(--card)] border border-primary/10 rounded-xl shadow-sm overflow-hidden">
-        <div className="p-6 pb-3">
-          <h3 className="text-[var(--foreground)] text-base font-bold">Recent Documents</h3>
-          <p className="text-xs text-[var(--muted-foreground)] mt-0.5">Last 20 processed documents</p>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Problem documents */}
+        <div className="bg-[var(--card)] border border-primary/10 rounded-xl shadow-sm overflow-hidden">
+          <div className="p-6 pb-3">
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="size-5 text-amber-500" />
+              <h3 className="text-[var(--foreground)] text-base font-bold">Problem Documents</h3>
+            </div>
+            <p className="text-xs text-[var(--muted-foreground)] mt-1">Documents with lowest confidence or extraction failures</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-t border-b border-primary/10 bg-[var(--background)]">
+                  <th className="text-left px-6 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Vendor</th>
+                  <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Conf</th>
+                  <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {problemDocs.map(d => {
+                  const conf = d.extraction_confidence
+                  const confDisplay = conf != null ? (conf * 100).toFixed(0) + '%' : '--'
+                  const confColor = conf != null && conf < 0.5 ? 'text-red-500' : 'text-amber-600'
+                  const status = d.status ?? 'unknown'
+                  const statusClasses: Record<string, string> = {
+                    approved: 'bg-emerald-50 text-emerald-700 border-emerald-200',
+                    needs_review: 'bg-amber-50 text-amber-700 border-amber-200',
+                    rejected: 'bg-red-50 text-red-700 border-red-200',
+                  }
+                  const statusCls = statusClasses[status] ?? 'bg-gray-50 text-gray-600 border-gray-200'
+                  return (
+                    <tr key={d.id} className="border-b border-primary/5 hover:bg-primary/[0.02] transition-colors">
+                      <td className="px-6 py-2.5 text-sm font-medium text-[var(--foreground)]">{d.vendor_name ?? d.file_name ?? '--'}</td>
+                      <td className={`px-4 py-2.5 text-sm text-center font-mono font-semibold ${confColor}`}>{confDisplay}</td>
+                      <td className="px-4 py-2.5 text-center">
+                        <span className={`text-[11px] font-bold px-2 py-0.5 rounded-full border ${statusCls}`}>
+                          {formatEnum(status)}
+                        </span>
+                      </td>
+                    </tr>
+                  )
+                })}
+                {problemDocs.length === 0 && (
+                  <tr><td colSpan={3} className="px-6 py-8 text-center text-[var(--muted-foreground)]">No problem documents — all above 80% confidence</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
         </div>
-        <div className="overflow-x-auto">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-t border-b border-primary/10 bg-[var(--background)]">
-                <th className="text-left px-6 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Vendor</th>
-                <th className="text-left px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Type</th>
-                <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Confidence</th>
-                <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Status</th>
-                <th className="text-right px-6 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Date</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recentDocs.map(d => {
-                const conf = d.extraction_confidence
-                let confDisplay = '--'
-                let confColor = 'text-[var(--muted-foreground)]'
-                if (conf != null) {
-                  confDisplay = (conf * 100).toFixed(0) + '%'
-                  confColor = conf >= 0.9 ? 'text-emerald-600' : conf >= 0.8 ? 'text-amber-600' : 'text-red-500'
-                }
-                const status = d.status ?? 'unknown'
-                const statusClasses: Record<string, string> = {
-                  approved: 'bg-emerald-50 text-emerald-700 border-emerald-200',
-                  needs_review: 'bg-amber-50 text-amber-700 border-amber-200',
-                  rejected: 'bg-red-50 text-red-700 border-red-200',
-                }
-                const statusCls = statusClasses[status] ?? 'bg-gray-50 text-gray-600 border-gray-200'
-                const date = d.created_at ? d.created_at.substring(0, 10) : '--'
 
-                return (
-                  <tr key={d.id} className="border-b border-primary/5 hover:bg-primary/[0.02] transition-colors">
-                    <td className="px-6 py-3 text-sm font-medium text-[var(--foreground)]">{d.vendor_name ?? '--'}</td>
-                    <td className="px-4 py-3 text-sm text-[var(--muted-foreground)]">{d.document_type ? formatEnum(d.document_type) : '--'}</td>
-                    <td className={`px-4 py-3 text-sm text-center font-mono font-medium ${confColor}`}>{confDisplay}</td>
-                    <td className="px-4 py-3 text-center">
-                      <span className={`text-[11px] font-bold px-2 py-0.5 rounded-full border ${statusCls}`}>
-                        {formatEnum(status)}
-                      </span>
-                    </td>
-                    <td className="px-6 py-3 text-sm text-right text-[var(--muted-foreground)]">{date}</td>
-                  </tr>
-                )
-              })}
-              {recentDocs.length === 0 && (
-                <tr><td colSpan={5} className="px-6 py-8 text-center text-[var(--muted-foreground)]">No documents found</td></tr>
-              )}
-            </tbody>
-          </table>
+        {/* Recent extraction log */}
+        <div className="bg-[var(--card)] border border-primary/10 rounded-xl shadow-sm overflow-hidden">
+          <div className="p-6 pb-3">
+            <div className="flex items-center gap-2">
+              <Search className="size-5 text-primary" />
+              <h3 className="text-[var(--foreground)] text-base font-bold">Recent Extraction Log</h3>
+            </div>
+            <p className="text-xs text-[var(--muted-foreground)] mt-1">Last 20 processed documents with model info</p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-t border-b border-primary/10 bg-[var(--background)]">
+                  <th className="text-left px-6 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Vendor</th>
+                  <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Model</th>
+                  <th className="text-center px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Conf</th>
+                  <th className="text-right px-4 py-2.5 text-[11px] font-bold text-[var(--muted-foreground)] uppercase tracking-wider">Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recentDocs.map(d => {
+                  const conf = d.extraction_confidence
+                  let confDisplay = '--'
+                  let confColor = 'text-[var(--muted-foreground)]'
+                  if (conf != null) {
+                    confDisplay = (conf * 100).toFixed(0) + '%'
+                    confColor = conf >= 0.9 ? 'text-emerald-600' : conf >= 0.8 ? 'text-amber-600' : 'text-red-500'
+                  }
+                  const date = d.created_at ? d.created_at.substring(0, 10) : '--'
+                  const model = d.extraction_model ?? '--'
+                  return (
+                    <tr key={d.id} className="border-b border-primary/5 hover:bg-primary/[0.02] transition-colors">
+                      <td className="px-6 py-2.5 text-sm font-medium text-[var(--foreground)] truncate max-w-[160px]">{d.vendor_name ?? d.file_name ?? '--'}</td>
+                      <td className="px-4 py-2.5 text-[11px] text-center font-mono text-[var(--muted-foreground)]">{model}</td>
+                      <td className={`px-4 py-2.5 text-sm text-center font-mono font-medium ${confColor}`}>{confDisplay}</td>
+                      <td className="px-4 py-2.5 text-sm text-right text-[var(--muted-foreground)]">{date}</td>
+                    </tr>
+                  )
+                })}
+                {recentDocs.length === 0 && (
+                  <tr><td colSpan={4} className="px-6 py-8 text-center text-[var(--muted-foreground)]">No documents found</td></tr>
+                )}
+              </tbody>
+            </table>
+          </div>
         </div>
       </div>
     </div>
@@ -509,28 +658,77 @@ function DocumentsTab({ docs, docStats }: { docs: Document[]; docStats: Document
 }
 
 // ================================================================
-// INVENTORY TAB
+// INVENTORY TAB — stock levels, low stock, expiring
 // ================================================================
 function InventoryTab({ stats, lowStock, expiring }: {
   stats: DashboardStats | undefined
   lowStock: InventoryItem[]
   expiring: InventoryItem[]
 }) {
+  // Find soonest expiry
+  const soonestExpiry = useMemo(() => {
+    if (expiring.length === 0) return null
+    const sorted = [...expiring]
+      .filter(i => i.expiry_date)
+      .sort((a, b) => (a.expiry_date ?? '').localeCompare(b.expiry_date ?? ''))
+    return sorted[0] ?? null
+  }, [expiring])
+
+  const soonestDays = soonestExpiry?.expiry_date
+    ? Math.max(0, Math.floor((new Date(soonestExpiry.expiry_date).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    : null
+
   return (
-    <div className="space-y-8">
-      {/* Stats */}
+    <div className="space-y-6">
+      {/* Headline insights */}
+      <div className="space-y-2">
+        {lowStock.length > 0 ? (
+          <Insight
+            text={`${lowStock.length} inventory item${lowStock.length > 1 ? 's' : ''} below reorder threshold — check low stock table below`}
+            variant="warn"
+          />
+        ) : (
+          <Insight text="All inventory items are above minimum stock levels" variant="good" />
+        )}
+        {expiring.length > 0 ? (
+          <Insight
+            text={`${expiring.length} item${expiring.length > 1 ? 's' : ''} expiring within 30 days${
+              soonestExpiry ? ` — soonest: ${soonestExpiry.product_name ?? 'unknown'} in ${soonestDays} days` : ''
+            }`}
+            variant={soonestDays != null && soonestDays <= 7 ? 'bad' : 'warn'}
+          />
+        ) : (
+          <Insight text="No inventory items expiring in the next 30 days" variant="good" />
+        )}
+      </div>
+
+      {/* Summary cards */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-        <StatCard label="Total Items" value={stats?.total_inventory_items ?? 0} sub="inventory records" icon={Package} />
-        <StatCard label="Active Orders" value={stats?.total_orders ?? 0} sub="orders in pipeline" icon={TrendingUp} />
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider">Total Items</span>
+            <Package className="size-5 opacity-50" />
+          </div>
+          <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{stats?.total_inventory_items ?? 0}</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">inventory records</div>
+        </div>
+        <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
+          <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
+            <span className="text-[11px] font-bold uppercase tracking-wider">Active Orders</span>
+            <TrendingUp className="size-5 opacity-50" />
+          </div>
+          <div className="text-3xl font-bold text-[var(--foreground)] tracking-tight">{stats?.total_orders ?? 0}</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">orders in pipeline</div>
+        </div>
         <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
           <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
             <span className="text-[11px] font-bold uppercase tracking-wider">Low Stock</span>
-            <Package className="size-5 opacity-50" />
+            <AlertTriangle className="size-5 opacity-50" />
           </div>
           <div className={`text-3xl font-bold tracking-tight ${lowStock.length > 0 ? 'text-amber-600' : 'text-[var(--foreground)]'}`}>
             {lowStock.length}
           </div>
-          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">items below threshold</div>
+          <div className="text-[11px] text-[var(--muted-foreground)] font-medium">below reorder threshold</div>
         </div>
         <div className="bg-[var(--card)] border border-primary/10 p-5 rounded-xl flex flex-col gap-1 shadow-sm">
           <div className="flex items-center justify-between text-[var(--muted-foreground)] mb-2">
@@ -547,7 +745,10 @@ function InventoryTab({ stats, lowStock, expiring }: {
       {/* Low stock table */}
       <div className="bg-[var(--card)] border border-primary/10 rounded-xl shadow-sm overflow-hidden">
         <div className="p-6 pb-3">
-          <h3 className="text-[var(--foreground)] text-base font-bold">Low Stock Items</h3>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="size-5 text-amber-500" />
+            <h3 className="text-[var(--foreground)] text-base font-bold">Low Stock Items</h3>
+          </div>
           <p className="text-xs text-[var(--muted-foreground)] mt-0.5">Items that need reordering</p>
         </div>
         <div className="overflow-x-auto">
@@ -582,7 +783,10 @@ function InventoryTab({ stats, lowStock, expiring }: {
       {/* Expiring items table */}
       <div className="bg-[var(--card)] border border-primary/10 rounded-xl shadow-sm overflow-hidden">
         <div className="p-6 pb-3">
-          <h3 className="text-[var(--foreground)] text-base font-bold">Expiring Items</h3>
+          <div className="flex items-center gap-2">
+            <Clock className="size-5 text-red-500" />
+            <h3 className="text-[var(--foreground)] text-base font-bold">Expiring Items</h3>
+          </div>
           <p className="text-xs text-[var(--muted-foreground)] mt-0.5">Items expiring within 30 days</p>
         </div>
         <div className="overflow-x-auto">
@@ -677,9 +881,9 @@ export function AnalyticsPage({ onError }: AnalyticsPageProps) {
     <div className="max-w-7xl mx-auto space-y-8">
       {/* Header */}
       <div>
-        <h2 className="text-3xl font-bold text-[var(--foreground)] tracking-tight">Analytics</h2>
+        <h2 className="text-3xl font-bold text-[var(--foreground)] tracking-tight">Lab Intelligence</h2>
         <p className="text-[var(--muted-foreground)] mt-2 text-sm">
-          Lab data insights across {stats?.total_documents ?? 0} documents, {stats?.total_vendors ?? 0} vendors, and {stats?.total_inventory_items ?? 0} inventory items.
+          Insights and analysis you cannot see on the Dashboard — AI performance, vendor risks, problem documents, inventory alerts.
         </p>
       </div>
 
@@ -706,13 +910,13 @@ export function AnalyticsPage({ onError }: AnalyticsPageProps) {
 
       {/* Tab content */}
       {activeTab === 'overview' && (
-        <OverviewTab stats={stats} docs={docs} docStats={docStats} />
+        <OverviewTab docs={docs} docStats={docStats} />
       )}
       {activeTab === 'vendors' && (
         <VendorsTab docs={docs} />
       )}
       {activeTab === 'documents' && (
-        <DocumentsTab docs={docs} docStats={docStats} />
+        <DocumentsTab docs={docs} />
       )}
       {activeTab === 'inventory' && (
         <InventoryTab stats={stats} lowStock={lowStock} expiring={expiring} />


### PR DESCRIPTION
## Summary

- Remove duplicate stats cards (total docs, approved, needs review, vendors, orders) — Dashboard already shows them
- Remove duplicate vendor top-5 and doc type pie from Overview tab — Dashboard has them
- **Overview → "Lab Intelligence"**: AI performance card with confidence sparkline, processing status pie (approved/review/rejected), extraction quality by vendor ranked lowest-first
- **Vendors**: Add vendor concentration analysis — top 3 vendors = X% of all documents, diversity metric
- **Documents**: Confidence distribution histogram, problem documents table (lowest confidence), recent extraction log with AI model info
- **Inventory**: Stock summary + low stock alerts + expiring items with headline insight
- Every section leads with **bold insight text** in plain English ("Your top 3 vendors account for 45% of all documents — high supplier concentration risk")

## Design rule

**Dashboard = action center.** Quick stats, quick actions, alerts.  
**Analytics = insights center.** What can I learn that I cannot see on Dashboard?

## Test plan

- [ ] Open Dashboard — verify stats cards, vendor top 5, doc type pie still there
- [ ] Open Analytics → Lab Intelligence tab — no duplicate stats, shows AI performance, processing status, vendor confidence ranking
- [ ] Open Analytics → Vendors tab — top 20 chart, vendor diversity card, vendor directory with filters
- [ ] Open Analytics → Documents tab — confidence histogram (no doc type pie), problem docs table, extraction log
- [ ] Open Analytics → Inventory tab — summary cards, low stock table, expiring items table
- [ ] Verify insight banners appear with contextual text (green/amber/red variants)
- [ ] Light theme and dark theme both render correctly

Generated with [Claude Code](https://claude.com/claude-code)