### PR TITLE
feat: vendor name normalization and clickable directory

### DIFF
--- a/scripts/normalize_existing_vendors.py
+++ b/scripts/normalize_existing_vendors.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""One-time script: normalize vendor_name on all existing documents.
+
+Usage (inside the app container or with DATABASE_URL set):
+    python scripts/normalize_existing_vendors.py
+
+Or via docker compose:
+    docker compose exec app python scripts/normalize_existing_vendors.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on path when run standalone
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from lab_manager.services.vendor_normalize import normalize_vendor  # noqa: E402
+
+
+def main() -> None:
+    from sqlalchemy import create_engine, select
+    from sqlalchemy.orm import Session
+
+    from lab_manager.models.document import Document  # noqa: E402
+
+    import os
+
+    db_url = os.environ.get(
+        "DATABASE_URL",
+        "postgresql+psycopg://labmanager:labmanager@localhost:5432/labmanager",
+    )
+    engine = create_engine(db_url)
+
+    updated = 0
+    skipped = 0
+
+    with Session(engine) as db:
+        docs = db.scalars(
+            select(Document).where(Document.vendor_name.isnot(None))
+        ).all()
+
+        for doc in docs:
+            original = doc.vendor_name
+            normalized = normalize_vendor(original)
+            if normalized != original:
+                doc.vendor_name = normalized
+                updated += 1
+                print(f"  [{doc.id}] {original!r} -> {normalized!r}")
+            else:
+                skipped += 1
+
+        db.commit()
+
+    print(f"\nDone: {updated} updated, {skipped} unchanged, {updated + skipped} total")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lab_manager/api/routes/documents.py
+++ b/src/lab_manager/api/routes/documents.py
@@ -163,9 +163,11 @@ def _run_extraction(doc_id: int) -> None:
             from lab_manager.config import get_settings
 
             settings = get_settings()
+            from lab_manager.services.vendor_normalize import normalize_vendor
+
             extracted = extract_from_text(ocr_text)
             doc.document_type = extracted.document_type
-            doc.vendor_name = extracted.vendor_name
+            doc.vendor_name = normalize_vendor(extracted.vendor_name)
             doc.extracted_data = extracted.model_dump()
             doc.extraction_model = settings.extraction_model
             doc.extraction_confidence = extracted.confidence
@@ -419,8 +421,13 @@ def update_document(
     document_id: int, body: DocumentUpdate, db: Session = Depends(get_db)
 ):
     """Partial update any document fields."""
+    from lab_manager.services.vendor_normalize import normalize_vendor
+
     doc = get_or_404(db, Document, document_id, "Document")
-    for key, value in body.model_dump(exclude_unset=True).items():
+    updates = body.model_dump(exclude_unset=True)
+    if "vendor_name" in updates and updates["vendor_name"]:
+        updates["vendor_name"] = normalize_vendor(updates["vendor_name"])
+    for key, value in updates.items():
         setattr(doc, key, value)
     db.flush()
     db.refresh(doc)

--- a/src/lab_manager/intake/pipeline.py
+++ b/src/lab_manager/intake/pipeline.py
@@ -121,8 +121,10 @@ def process_document(image_path: Path, db: Session) -> Document:
             doc.status = DocumentStatus.needs_review
             doc.review_notes = "Extraction failed: no result returned"
         else:
+            from lab_manager.services.vendor_normalize import normalize_vendor
+
             doc.document_type = extracted.document_type
-            doc.vendor_name = extracted.vendor_name
+            doc.vendor_name = normalize_vendor(extracted.vendor_name)
             doc.extracted_data = extracted.model_dump()
             doc.extraction_model = settings.extraction_model
             doc.extraction_confidence = extracted.confidence

--- a/src/lab_manager/services/vendor_normalize.py
+++ b/src/lab_manager/services/vendor_normalize.py
@@ -1,0 +1,90 @@
+"""Vendor name normalization — map OCR variants to canonical names."""
+
+from __future__ import annotations
+
+VENDOR_ALIASES: dict[str, str] = {
+    # Sigma-Aldrich / MilliporeSigma / Merck
+    "sigma-aldrich": "Sigma-Aldrich",
+    "sigma-aldrich, inc.": "Sigma-Aldrich",
+    "sigma-aldrich, inc": "Sigma-Aldrich",
+    "sigma aldrich": "Sigma-Aldrich",
+    "sigma aldrich, inc.": "Sigma-Aldrich",
+    "milliporesigma": "MilliporeSigma",
+    "milliporesigma corporation": "MilliporeSigma",
+    "emd millipore corporation": "MilliporeSigma",
+    # Thermo Fisher / Fisher Scientific
+    "fisher scientific": "Fisher Scientific",
+    "fisher scientific co": "Fisher Scientific",
+    "fisher scientific co.": "Fisher Scientific",
+    "fisher scientific company": "Fisher Scientific",
+    "fisher scientific technology inc.": "Fisher Scientific",
+    "thermo fisher scientific chemicals inc.": "Thermo Fisher Scientific",
+    "thermofisher scientific": "Thermo Fisher Scientific",
+    # Bio-Rad
+    "bio-rad": "Bio-Rad Laboratories",
+    "bio-rad laboratories, inc.": "Bio-Rad Laboratories",
+    # Invitrogen / Life Technologies
+    "invitrogen": "Invitrogen",
+    "invitrogen by life technologies": "Invitrogen",
+    "invitrogen\u2122 by life technologies\u2122": "Invitrogen",
+    "life technologies": "Invitrogen",
+    "life technologies corpora": "Invitrogen",
+    # McMaster-Carr
+    "mcmaster-carr": "McMaster-Carr",
+    # Westnet
+    "westnet": "Westnet",
+    "westnet - canton": "Westnet",
+    "westnet inc.": "Westnet",
+    # Genesee
+    "genesee scientific": "Genesee Scientific",
+    "genesee scientific, llc": "Genesee Scientific",
+    # MedChemExpress
+    "medchemexpress llc": "MedChemExpress",
+    "medchem express llc": "MedChemExpress",
+    # Patterson
+    "patterson dental supply, inc.": "Patterson Dental",
+    "patterson logistics services, inc.": "Patterson Dental",
+    # Medline
+    "medline": "Medline Industries",
+    "medline industries lp": "Medline Industries",
+    # Grainger
+    "grainger": "Grainger",
+    "ww grainger": "Grainger",
+    # CDW
+    "cdw-g": "CDW",
+    "cdw logistics llc": "CDW",
+    # DigiKey
+    "digikey": "DigiKey Electronics",
+    "digikey electronics": "DigiKey Electronics",
+    "digikay": "DigiKey Electronics",
+    # PluriSelect
+    "pluriselect usa, inc.": "PluriSelect",
+    "pluriselect usa, inc": "PluriSelect",
+    # Creative Biolabs
+    "creative biolabs": "Creative Biolabs",
+    "creative biolabs inc.": "Creative Biolabs",
+    # Nikon
+    "nikon": "Nikon Instruments",
+    "nikon instruments consignment": "Nikon Instruments",
+}
+
+
+def _normalize_key(s: str) -> str:
+    """Produce a stable lookup key: lowercase, stripped, no trailing dots."""
+    return s.lower().strip().rstrip(".")
+
+
+# Pre-build lookup table with normalized keys so both "inc." and "inc" match
+_LOOKUP: dict[str, str] = {_normalize_key(k): v for k, v in VENDOR_ALIASES.items()}
+
+
+def normalize_vendor(name: str | None) -> str | None:
+    """Normalize vendor name to canonical form.
+
+    Lookup is case-insensitive with trailing-dot stripping.
+    Returns the canonical name if matched, otherwise the original name unchanged.
+    """
+    if not name:
+        return name
+    key = _normalize_key(name)
+    return _LOOKUP.get(key, name)

--- a/tests/test_vendor_normalize.py
+++ b/tests/test_vendor_normalize.py
@@ -1,0 +1,115 @@
+"""Tests for vendor name normalization."""
+
+import pytest
+
+from lab_manager.services.vendor_normalize import VENDOR_ALIASES, normalize_vendor
+
+
+class TestNormalizeVendor:
+    """Unit tests for normalize_vendor()."""
+
+    def test_none_returns_none(self):
+        assert normalize_vendor(None) is None
+
+    def test_empty_string_returns_empty(self):
+        assert normalize_vendor("") == ""
+
+    def test_exact_match_lowercase(self):
+        assert normalize_vendor("sigma-aldrich") == "Sigma-Aldrich"
+
+    def test_case_insensitive(self):
+        assert normalize_vendor("SIGMA-ALDRICH") == "Sigma-Aldrich"
+        assert normalize_vendor("Sigma-Aldrich") == "Sigma-Aldrich"
+        assert normalize_vendor("sigma-ALDRICH") == "Sigma-Aldrich"
+
+    def test_trailing_dot_stripped(self):
+        assert normalize_vendor("Fisher Scientific Co.") == "Fisher Scientific"
+
+    def test_whitespace_stripped(self):
+        assert normalize_vendor("  sigma-aldrich  ") == "Sigma-Aldrich"
+
+    def test_milliporesigma_variants(self):
+        assert normalize_vendor("MilliporeSigma") == "MilliporeSigma"
+        assert normalize_vendor("MilliporeSigma Corporation") == "MilliporeSigma"
+        assert normalize_vendor("EMD Millipore Corporation") == "MilliporeSigma"
+
+    def test_fisher_scientific_variants(self):
+        assert normalize_vendor("FISHER SCIENTIFIC CO") == "Fisher Scientific"
+        assert normalize_vendor("FISHER SCIENTIFIC") == "Fisher Scientific"
+        assert normalize_vendor("Fisher Scientific Company") == "Fisher Scientific"
+
+    def test_thermo_fisher(self):
+        assert (
+            normalize_vendor("THERMO FISHER SCIENTIFIC CHEMICALS INC.")
+            == "Thermo Fisher Scientific"
+        )
+        assert normalize_vendor("ThermoFisher SCIENTIFIC") == "Thermo Fisher Scientific"
+
+    def test_invitrogen_life_technologies(self):
+        assert normalize_vendor("invitrogen") == "Invitrogen"
+        assert normalize_vendor("Life Technologies") == "Invitrogen"
+        assert normalize_vendor("invitrogen by life technologies") == "Invitrogen"
+
+    def test_bio_rad(self):
+        assert normalize_vendor("Bio-Rad") == "Bio-Rad Laboratories"
+        assert normalize_vendor("Bio-Rad Laboratories, Inc.") == "Bio-Rad Laboratories"
+
+    def test_digikey_typo(self):
+        assert normalize_vendor("Digikay") == "DigiKey Electronics"
+        assert normalize_vendor("DigiKey") == "DigiKey Electronics"
+
+    def test_unknown_vendor_passthrough(self):
+        assert normalize_vendor("Acme Labs") == "Acme Labs"
+        assert normalize_vendor("Some New Vendor") == "Some New Vendor"
+
+    def test_westnet_variants(self):
+        assert normalize_vendor("Westnet") == "Westnet"
+        assert normalize_vendor("Westnet - Canton") == "Westnet"
+        assert normalize_vendor("Westnet Inc.") == "Westnet"
+
+    def test_medchemexpress_variants(self):
+        assert normalize_vendor("MedChemExpress LLC") == "MedChemExpress"
+        assert normalize_vendor("MedChem Express LLC") == "MedChemExpress"
+
+    def test_pluriselect_variants(self):
+        assert normalize_vendor("PluriSelect usa, Inc.") == "PluriSelect"
+        assert normalize_vendor("Pluriselect usa, Inc") == "PluriSelect"
+
+    def test_creative_biolabs(self):
+        assert normalize_vendor("Creative Biolabs") == "Creative Biolabs"
+        assert normalize_vendor("Creative Biolabs Inc.") == "Creative Biolabs"
+
+    def test_nikon_variants(self):
+        assert normalize_vendor("Nikon") == "Nikon Instruments"
+        assert normalize_vendor("Nikon Instruments Consignment") == "Nikon Instruments"
+
+    def test_grainger_variants(self):
+        assert normalize_vendor("Grainger") == "Grainger"
+        assert normalize_vendor("WW Grainger") == "Grainger"
+
+    def test_cdw_variants(self):
+        assert normalize_vendor("CDW-G") == "CDW"
+        assert normalize_vendor("CDW Logistics LLC") == "CDW"
+
+    def test_every_alias_has_canonical_value(self):
+        """Every alias key must map to a non-empty canonical name."""
+        for alias_key, canonical in VENDOR_ALIASES.items():
+            assert canonical, f"Alias '{alias_key}' maps to empty canonical name"
+            assert canonical.strip() == canonical, (
+                f"Canonical '{canonical}' has whitespace"
+            )
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("sigma-aldrich, inc.", "Sigma-Aldrich"),
+            ("Sigma Aldrich, Inc.", "Sigma-Aldrich"),
+            ("FISHER SCIENTIFIC CO.", "Fisher Scientific"),
+            ("Patterson Dental Supply, Inc.", "Patterson Dental"),
+            ("Patterson Logistics Services, Inc.", "Patterson Dental"),
+            ("Medline Industries LP", "Medline Industries"),
+            ("Genesee Scientific, LLC", "Genesee Scientific"),
+        ],
+    )
+    def test_parametrized_aliases(self, raw, expected):
+        assert normalize_vendor(raw) == expected

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -278,9 +278,9 @@ export const inventory = {
 
 // Documents
 export const documents = {
-  list: (page = 1, pageSize = 20, status?: string) =>
+  list: (page = 1, pageSize = 20, status?: string, vendorName?: string) =>
     apiFetch<ApiResponse<Document>>(
-      `/documents?page=${page}&page_size=${pageSize}${status ? `&status=${status}` : ''}`,
+      `/documents?page=${page}&page_size=${pageSize}${status ? `&status=${status}` : ''}${vendorName ? `&vendor_name=${encodeURIComponent(vendorName)}` : ''}`,
     ),
   get: (id: number) => apiFetch<Document>(`/documents/${id}`),
   reviewQueue: () =>

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import {
   BarChart3, FileText, Package, Store, Clock,
@@ -328,7 +329,7 @@ function OverviewTab({ docs, docStats }: {
 // ================================================================
 // VENDORS TAB — enhanced with diversity insight
 // ================================================================
-function VendorsTab({ docs }: { docs: Document[] }) {
+function VendorsTab({ docs, navigate }: { docs: Document[]; navigate: ReturnType<typeof useNavigate> }) {
   const [filter, setFilter] = useState<'all' | 'reagents' | 'equipment' | 'supplies'>('all')
 
   const vendorData = useMemo(() => {
@@ -457,13 +458,14 @@ function VendorsTab({ docs }: { docs: Document[] }) {
         </div>
         <div className="flex flex-wrap gap-2">
           {filteredVendors.map(v => (
-            <span
+            <button
               key={v.name}
-              className="inline-block px-2.5 py-1 rounded-md bg-primary/5 text-primary text-[13px] font-medium"
-              title={`${v.count} document${v.count > 1 ? 's' : ''}`}
+              onClick={() => navigate(`/documents?vendor=${encodeURIComponent(v.name)}`)}
+              className="inline-block px-2.5 py-1 rounded-md bg-primary/5 text-primary text-[13px] font-medium hover:bg-primary/10 hover:underline cursor-pointer transition-colors"
+              title={`${v.count} document${v.count > 1 ? 's' : ''} — click to view`}
             >
               {v.name} <span className="text-primary/50 ml-1">{v.count}</span>
-            </span>
+            </button>
           ))}
           {filteredVendors.length === 0 && (
             <p className="text-sm text-[var(--muted-foreground)] py-4">No vendors in this category</p>
@@ -825,6 +827,7 @@ function InventoryTab({ stats, lowStock, expiring }: {
 // MAIN PAGE
 // ================================================================
 export function AnalyticsPage({ onError }: AnalyticsPageProps) {
+  const navigate = useNavigate()
   const [activeTab, setActiveTab] = useState<TabValue>('overview')
 
   // Fetch all data
@@ -913,7 +916,7 @@ export function AnalyticsPage({ onError }: AnalyticsPageProps) {
         <OverviewTab docs={docs} docStats={docStats} />
       )}
       {activeTab === 'vendors' && (
-        <VendorsTab docs={docs} />
+        <VendorsTab docs={docs} navigate={navigate} />
       )}
       {activeTab === 'documents' && (
         <DocumentsTab docs={docs} />

--- a/web/src/pages/DocumentsPage.tsx
+++ b/web/src/pages/DocumentsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { documents as docApi } from '@/lib/api'
 import { Search, Upload, FileText, ChevronLeft, ChevronRight } from 'lucide-react'
@@ -59,6 +59,8 @@ function formatShortDate(dateStr?: string): string {
 
 export function DocumentsPage({ onError }: DocumentsPageProps) {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const vendorFilter = searchParams.get('vendor') ?? undefined
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState('')
   const [statusFilter, setStatusFilter] = useState<string>('all')
@@ -69,9 +71,9 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
     isLoading,
     error,
   } = useQuery({
-    queryKey: ['documents', page, statusFilter],
+    queryKey: ['documents', page, statusFilter, vendorFilter],
     queryFn: () =>
-      docApi.list(page, pageSize, statusFilter !== 'all' ? statusFilter : undefined),
+      docApi.list(page, pageSize, statusFilter !== 'all' ? statusFilter : undefined, vendorFilter),
   })
 
   useEffect(() => {
@@ -145,6 +147,22 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
             </button>
           )
         })}
+        {vendorFilter && (
+          <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700 border border-blue-200">
+            Vendor: {vendorFilter}
+            <button
+              onClick={() => {
+                searchParams.delete('vendor')
+                setSearchParams(searchParams)
+                setPage(1)
+              }}
+              className="ml-1 text-blue-400 hover:text-blue-700"
+              aria-label="Clear vendor filter"
+            >
+              &times;
+            </button>
+          </span>
+        )}
       </div>
 
       {/* Table Container */}


### PR DESCRIPTION
## Summary
- Add `vendor_normalize.py` with 30+ alias mappings to reduce OCR-caused vendor duplicates (e.g. "SIGMA-ALDRICH" + "Sigma Aldrich, Inc." + "Sigma-Aldrich" all map to "Sigma-Aldrich")
- Integrate normalization into intake pipeline, document upload API, and document PATCH endpoint
- Vendor names in Analytics "Vendor Directory" are now clickable buttons that navigate to `/documents?vendor=VendorName`
- DocumentsPage reads `?vendor=` query param for server-side filtering with a dismissible filter badge
- One-time migration script (`scripts/normalize_existing_vendors.py`) updated 105 of 260 existing documents

## Test plan
- [x] 28 unit tests in `tests/test_vendor_normalize.py` — all passing
- [ ] Verify vendor clicks in Analytics navigate to filtered Documents page
- [ ] Verify clearing the vendor filter badge shows all documents again
- [ ] Verify new document uploads get normalized vendor names

Generated with [Claude Code](https://claude.com/claude-code)