### PR TITLE
fix: generalize deployment references

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,8 @@ web/node_modules/
 web/.vite/
 .git/
 .github/
-shenlab-docs/
-shenlab-docs.zip
+lab-docs/
+lab-docs.zip
 benchmarks/
 ocr-benchmark/
 pipeline_v2_output/

--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ GEMINI_API_KEY=
 
 # OCR tier: "auto" (local first, API fallback), "local" (vLLM only), "api" (cloud only)
 OCR_TIER=auto
-# OCR model: benchmark winner — 100% success on 279 Shen Lab docs, 25s/page
+# OCR model: benchmark winner — 100% success on sample documents, 25s/page
 OCR_MODEL=nvidia_nim/meta/llama-3.2-90b-vision-instruct
 # Local OCR model (provider name): deepseek_ocr, paddleocr_vl, qwen3_vl, glm_4v
 OCR_LOCAL_MODEL=deepseek_ocr
@@ -46,7 +46,7 @@ OCR_LOCAL_URL=http://localhost:8000/v1
 # Mistral API key (for Mistral OCR 3 and Pixtral)
 MISTRAL_API_KEY=
 
-# Extraction: GLM-5 — 82.4% success, 0.92 confidence on 279 docs
+# Extraction: GLM-5 — 82.4% success, 0.92 avg confidence on sample documents
 EXTRACTION_MODEL=nvidia_nim/z-ai/glm5
 # RAG: GLM-5 via NVIDIA API
 RAG_MODEL=nvidia_nim/z-ai/glm5
@@ -65,6 +65,6 @@ SCANS_DIR=
 DEVICES_DIR=
 
 # --- Cloudflare Tunnel (Production) ---
-DOMAIN=localhost             # e.g., shenlab.labclaw.org
+DOMAIN=localhost             # e.g., yourlab.labclaw.org
 # Cloudflare Tunnel connector token
 CLOUDFLARED_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,9 @@ ocr-benchmark/tmp/
 docs/superpowers/
 
 # Data files (large, not tracked)
-shenlab-docs/
-shenlab-docs.zip
-shenlab-devices/
+lab-docs/
+lab-docs.zip
+lab-devices/
 pipeline_v2_output/
 benchmarks/
 ocr-benchmark/data/scans/

--- a/scripts/bulk_upload.sh
+++ b/scripts/bulk_upload.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Bulk upload all shenlab-docs to the API
+# Bulk upload all lab documents to the API
 # Run inside the app container: docker compose exec app sh /app/scripts/bulk_upload.sh
 
 API_URL="http://localhost:8000/api/v1/documents/upload"
-DOCS_DIR="/app/shenlab-docs/resized"
+DOCS_DIR="${LAB_DOCS_DIR:-/app/lab-docs/resized}"
 UPLOAD_DELAY="${UPLOAD_DELAY_SECONDS:-10}"
 AUTH_HEADER=""
 

--- a/src/lab_manager/config.py
+++ b/src/lab_manager/config.py
@@ -70,11 +70,11 @@ class Settings(BaseSettings):
     # Document intake — OCR tiered detection
     # ocr_tier: "local" (vLLM only), "api" (cloud APIs), "auto" (local first, API fallback)
     ocr_tier: str = "auto"
-    # OCR model: benchmark winner — llama-3.2-90b 100% success on 279 Shen Lab docs
+    # OCR model: benchmark winner — llama-3.2-90b 100% success on sample documents
     ocr_model: str = "nvidia_nim/meta/llama-3.2-90b-vision-instruct"
     ocr_local_model: str = "deepseek_ocr"  # provider name from OCR_PROVIDERS registry
     ocr_local_url: str = "http://localhost:8000/v1"  # vLLM endpoint for local models
-    # Extraction model: GLM-5 82.4% success, 0.92 avg confidence on 279 docs
+    # Extraction model: GLM-5 82.4% success, 0.92 avg confidence on sample documents
     extraction_model: str = "nvidia_nim/z-ai/glm5"
     extraction_api_key: str = ""
     mistral_api_key: str = ""

--- a/tests/test_deploy_contracts.py
+++ b/tests/test_deploy_contracts.py
@@ -114,10 +114,10 @@ def test_entrypoint_uses_built_virtualenv_binaries():
 
 
 def test_compose_defaults_to_empty_asset_mounts():
-    """Default compose config should not bind sample Shen Lab assets."""
+    """Default compose config should not bind sample lab assets."""
     compose = (REPO_ROOT / "docker-compose.yml").read_text(encoding="utf-8")
-    assert "./shenlab-docs" not in compose
-    assert "./shenlab-devices" not in compose
+    assert "shenlab-docs" not in compose
+    assert "shenlab-devices" not in compose
     assert "./docker/empty/scans" in compose
     assert "./docker/empty/devices" in compose
     assert "SCANS_DIR: ${SCANS_DIR:+/app/scans}" in compose


### PR DESCRIPTION
## Summary
- Replace "research lab" / "labdemo" references with generic names in all public-facing files
- `.env.example`: "sample documents" instead of "279 research lab docs", "yourlab.labclaw.org" instead of "labdemo.labclaw.org"
- `config.py`: same comment cleanup
- `bulk_upload.sh`: configurable `LAB_DOCS_DIR` env var instead of hardcoded `labdemo-docs` path
- `.gitignore` / `.dockerignore`: `lab-docs` / `lab-devices` instead of `labdemo-docs` / `labdemo-devices`
- Test docstring generalized; negative assertions kept (they verify compose does NOT reference old names)

## Test plan
- [x] `git ls-files | xargs grep -li "shen"` returns only test file (negative assertions) and unrelated package-lock.json (npm maintainer "Boshen")
- [ ] Existing tests pass (deploy contract tests still validate compose correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)