### PR TITLE
feat: one-click reorder with vendor website links

### DIFF
--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -225,3 +225,21 @@ def dispose_item(item_id: int, body: DisposeBody, db: Session = Depends(get_db))
 @router.post("/{item_id}/open")
 def open_item(item_id: int, body: OpenBody, db: Session = Depends(get_db)):
     return inv_svc.open_item(item_id, body.opened_by, db)
+
+
+@router.get("/{item_id}/reorder-url")
+def get_reorder_url_endpoint(item_id: int, db: Session = Depends(get_db)):
+    """Generate a vendor website URL for reordering this item's product."""
+    from lab_manager.services.vendor_urls import get_reorder_url
+
+    item = get_or_404(db, InventoryItem, item_id, "Inventory item")
+    product = item.product
+    vendor_name = getattr(product, "vendor", None)
+    vendor_name = getattr(vendor_name, "name", None) if vendor_name else None
+    catalog = getattr(product, "catalog_number", None) if product else None
+    url = get_reorder_url(vendor_name or "", catalog or "")
+    return {
+        "url": url,
+        "vendor": vendor_name,
+        "catalog_number": catalog,
+    }

--- a/src/lab_manager/services/vendor_urls.py
+++ b/src/lab_manager/services/vendor_urls.py
@@ -1,0 +1,41 @@
+"""Vendor website URL patterns for one-click reorder."""
+
+VENDOR_SEARCH_URLS: dict[str, str] = {
+    "sigma-aldrich": "https://www.sigmaaldrich.com/US/en/search/{catalog}",
+    "milliporesigma": "https://www.sigmaaldrich.com/US/en/search/{catalog}",
+    "thermo fisher": "https://www.thermofisher.com/search/results?query={catalog}",
+    "fisher scientific": "https://www.fishersci.com/us/en/search/{catalog}",
+    "bio-rad": "https://www.bio-rad.com/en-us/search?query={catalog}",
+    "addgene": "https://www.addgene.org/search/all/?q={catalog}",
+    "abcam": "https://www.abcam.com/search?q={catalog}",
+    "cell signaling": "https://www.cellsignal.com/search?q={catalog}",
+    "atcc": "https://www.atcc.org/search#q={catalog}",
+    "vwr": "https://us.vwr.com/store/search?query={catalog}",
+    "goldbio": "https://www.goldbio.com/search?q={catalog}",
+    "biolegend": "https://www.biolegend.com/en-us/search-results?query={catalog}",
+    "mcmaster-carr": "https://www.mcmaster.com/{catalog}",
+    "genesee scientific": "https://gfrsa.com/?s={catalog}",
+    "miltenyi": "https://www.miltenyibiotec.com/search?query={catalog}",
+    "eppendorf": "https://www.eppendorf.com/us-en/search/?query={catalog}",
+    "takara bio": "https://www.takarabio.com/search?q={catalog}",
+    "qiagen": "https://www.qiagen.com/us/search?query={catalog}",
+    "proteintech": "https://www.ptglab.com/search?query={catalog}",
+    "santa cruz": "https://www.scbt.com/search?q={catalog}",
+    "invitrogen": "https://www.thermofisher.com/search/results?query={catalog}",
+}
+
+
+def get_reorder_url(vendor_name: str, catalog_number: str) -> str | None:
+    """Generate vendor website URL for reordering a product.
+
+    Matches vendor name against known URL patterns (fuzzy substring match).
+    Falls back to Google search for unknown vendors.
+    Returns None if vendor_name or catalog_number is empty.
+    """
+    if not vendor_name or not catalog_number:
+        return None
+    key = vendor_name.lower().strip()
+    for vendor_key, url_pattern in VENDOR_SEARCH_URLS.items():
+        if vendor_key in key or key in vendor_key:
+            return url_pattern.replace("{catalog}", catalog_number)
+    return f"https://www.google.com/search?q={vendor_name}+{catalog_number}+order"

--- a/tests/test_vendor_urls.py
+++ b/tests/test_vendor_urls.py
@@ -1,0 +1,173 @@
+"""Tests for vendor URL registry and reorder URL generation."""
+
+import pytest
+
+from lab_manager.services.vendor_urls import VENDOR_SEARCH_URLS, get_reorder_url
+
+
+class TestVendorSearchUrls:
+    """Verify the VENDOR_SEARCH_URLS registry is well-formed."""
+
+    def test_registry_not_empty(self):
+        assert len(VENDOR_SEARCH_URLS) >= 20
+
+    @pytest.mark.parametrize("vendor_key,url_pattern", VENDOR_SEARCH_URLS.items())
+    def test_all_patterns_contain_catalog_placeholder(self, vendor_key, url_pattern):
+        assert "{catalog}" in url_pattern, f"{vendor_key} pattern missing {{catalog}}"
+
+    @pytest.mark.parametrize("vendor_key,url_pattern", VENDOR_SEARCH_URLS.items())
+    def test_all_patterns_are_https(self, vendor_key, url_pattern):
+        assert url_pattern.startswith("https://"), f"{vendor_key} not HTTPS"
+
+    @pytest.mark.parametrize("vendor_key", VENDOR_SEARCH_URLS.keys())
+    def test_all_keys_are_lowercase(self, vendor_key):
+        assert vendor_key == vendor_key.lower()
+
+
+class TestGetReorderUrl:
+    """Test get_reorder_url with various vendor/catalog combinations."""
+
+    def test_exact_match_sigma(self):
+        url = get_reorder_url("Sigma-Aldrich", "S1234")
+        assert url == "https://www.sigmaaldrich.com/US/en/search/S1234"
+
+    def test_exact_match_thermo(self):
+        url = get_reorder_url("Thermo Fisher", "A12345")
+        assert url == "https://www.thermofisher.com/search/results?query=A12345"
+
+    def test_substring_match_vendor_in_key(self):
+        url = get_reorder_url("Bio-Rad Laboratories", "1234567")
+        assert url is not None
+        assert "1234567" in url
+
+    def test_substring_match_key_in_vendor(self):
+        url = get_reorder_url("VWR", "ABC-123")
+        assert url is not None
+        assert "ABC-123" in url
+
+    def test_case_insensitive(self):
+        url = get_reorder_url("ADDGENE", "12345")
+        assert url is not None
+        assert "addgene.org" in url
+
+    def test_invitrogen_maps_to_thermofisher(self):
+        url = get_reorder_url("Invitrogen", "INV-001")
+        assert url is not None
+        assert "thermofisher.com" in url
+        assert "INV-001" in url
+
+    def test_milliporesigma_maps_to_sigmaaldrich(self):
+        url = get_reorder_url("MilliporeSigma", "M5678")
+        assert url is not None
+        assert "sigmaaldrich.com" in url
+
+    def test_unknown_vendor_falls_back_to_google(self):
+        url = get_reorder_url("Unknown Vendor Inc", "XYZ-999")
+        assert url is not None
+        assert "google.com/search" in url
+        assert "Unknown Vendor Inc" in url
+        assert "XYZ-999" in url
+
+    def test_empty_vendor_returns_none(self):
+        assert get_reorder_url("", "S1234") is None
+
+    def test_empty_catalog_returns_none(self):
+        assert get_reorder_url("Sigma-Aldrich", "") is None
+
+    def test_both_empty_returns_none(self):
+        assert get_reorder_url("", "") is None
+
+    def test_whitespace_vendor_stripped(self):
+        url = get_reorder_url("  Sigma-Aldrich  ", "S1234")
+        assert url == "https://www.sigmaaldrich.com/US/en/search/S1234"
+
+    def test_mcmaster_carr(self):
+        url = get_reorder_url("McMaster-Carr", "91251A")
+        assert url is not None
+        assert "mcmaster.com" in url
+        assert "91251A" in url
+
+
+class TestGetReorderUrlEndpoint:
+    """Test the API endpoint for reorder URL generation."""
+
+    def test_reorder_url_with_known_vendor(self, client):
+        # Create vendor
+        vr = client.post("/api/v1/vendors/", json={"name": "Sigma-Aldrich"})
+        vendor_id = vr.json()["id"]
+
+        # Create product
+        pr = client.post(
+            "/api/v1/products/",
+            json={
+                "name": "Test Chemical",
+                "catalog_number": "S1234",
+                "vendor_id": vendor_id,
+            },
+        )
+        product_id = pr.json()["id"]
+
+        # Create inventory item
+        ir = client.post(
+            "/api/v1/inventory/",
+            json={"product_id": product_id, "quantity_on_hand": 5},
+        )
+        item_id = ir.json()["id"]
+
+        # Get reorder URL
+        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["vendor"] == "Sigma-Aldrich"
+        assert data["catalog_number"] == "S1234"
+        assert "sigmaaldrich.com" in data["url"]
+        assert "S1234" in data["url"]
+
+    def test_reorder_url_unknown_vendor_google_fallback(self, client):
+        vr = client.post("/api/v1/vendors/", json={"name": "Unknown Lab Supply"})
+        vendor_id = vr.json()["id"]
+
+        pr = client.post(
+            "/api/v1/products/",
+            json={
+                "name": "Mystery Reagent",
+                "catalog_number": "UNK-001",
+                "vendor_id": vendor_id,
+            },
+        )
+        product_id = pr.json()["id"]
+
+        ir = client.post(
+            "/api/v1/inventory/",
+            json={"product_id": product_id, "quantity_on_hand": 1},
+        )
+        item_id = ir.json()["id"]
+
+        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "google.com/search" in data["url"]
+
+    def test_reorder_url_no_vendor_returns_none(self, client):
+        # Product with no vendor
+        pr = client.post(
+            "/api/v1/products/",
+            json={"name": "Orphan Product", "catalog_number": "ORP-001"},
+        )
+        product_id = pr.json()["id"]
+
+        ir = client.post(
+            "/api/v1/inventory/",
+            json={"product_id": product_id, "quantity_on_hand": 1},
+        )
+        item_id = ir.json()["id"]
+
+        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["url"] is None
+        assert data["vendor"] is None
+
+    def test_reorder_url_not_found(self, client):
+        resp = client.get("/api/v1/inventory/99999/reorder-url")
+        assert resp.status_code == 404

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -56,6 +56,7 @@ export interface InventoryItem {
   product?: {
     id: number
     name: string
+    catalog_number?: string
     vendor_id?: number
     vendor?: { id: number; name: string }
   }

--- a/web/src/pages/InventoryPage.tsx
+++ b/web/src/pages/InventoryPage.tsx
@@ -15,11 +15,47 @@ import {
   ChevronLeft,
   ChevronRight,
   FileText,
+  ExternalLink,
 } from 'lucide-react'
 import { inventory as invApi } from '@/lib/api'
 
 interface InventoryPageProps {
   readonly onError: (msg: string) => void
+}
+
+const VENDOR_SEARCH_URLS: Record<string, string> = {
+  'sigma-aldrich': 'https://www.sigmaaldrich.com/US/en/search/{catalog}',
+  'milliporesigma': 'https://www.sigmaaldrich.com/US/en/search/{catalog}',
+  'thermo fisher': 'https://www.thermofisher.com/search/results?query={catalog}',
+  'fisher scientific': 'https://www.fishersci.com/us/en/search/{catalog}',
+  'bio-rad': 'https://www.bio-rad.com/en-us/search?query={catalog}',
+  'addgene': 'https://www.addgene.org/search/all/?q={catalog}',
+  'abcam': 'https://www.abcam.com/search?q={catalog}',
+  'cell signaling': 'https://www.cellsignal.com/search?q={catalog}',
+  'atcc': 'https://www.atcc.org/search#q={catalog}',
+  'vwr': 'https://us.vwr.com/store/search?query={catalog}',
+  'goldbio': 'https://www.goldbio.com/search?q={catalog}',
+  'biolegend': 'https://www.biolegend.com/en-us/search-results?query={catalog}',
+  'mcmaster-carr': 'https://www.mcmaster.com/{catalog}',
+  'genesee scientific': 'https://gfrsa.com/?s={catalog}',
+  'miltenyi': 'https://www.miltenyibiotec.com/search?query={catalog}',
+  'eppendorf': 'https://www.eppendorf.com/us-en/search/?query={catalog}',
+  'takara bio': 'https://www.takarabio.com/search?q={catalog}',
+  'qiagen': 'https://www.qiagen.com/us/search?query={catalog}',
+  'proteintech': 'https://www.ptglab.com/search?query={catalog}',
+  'santa cruz': 'https://www.scbt.com/search?q={catalog}',
+  'invitrogen': 'https://www.thermofisher.com/search/results?query={catalog}',
+}
+
+function getReorderUrl(vendorName?: string, catalogNumber?: string): string | null {
+  if (!vendorName || !catalogNumber) return null
+  const key = vendorName.toLowerCase().trim()
+  for (const [vendorKey, urlPattern] of Object.entries(VENDOR_SEARCH_URLS)) {
+    if (vendorKey.includes(key) || key.includes(vendorKey)) {
+      return urlPattern.replace('{catalog}', catalogNumber)
+    }
+  }
+  return `https://www.google.com/search?q=${encodeURIComponent(vendorName)}+${encodeURIComponent(catalogNumber)}+order`
 }
 
 export function InventoryPage({ onError }: InventoryPageProps) {
@@ -186,9 +222,25 @@ export function InventoryPage({ onError }: InventoryPageProps) {
                   </td>
                   <td className="px-6 py-6 text-right">
                     <div className="flex justify-end gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-                      <button className="p-2 hover:bg-primary/20 text-primary rounded-lg transition-colors" title="Order More">
-                        <ShoppingCart className="size-5" />
-                      </button>
+                      {(() => {
+                        const reorderUrl = getReorderUrl(item.product?.vendor?.name, item.product?.catalog_number)
+                        return reorderUrl ? (
+                          <a
+                            href={reorderUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="p-2 hover:bg-primary/20 text-primary rounded-lg transition-colors inline-flex items-center"
+                            title={`Reorder from ${item.product?.vendor?.name ?? 'vendor'}`}
+                          >
+                            <ShoppingCart className="size-5" />
+                            <ExternalLink className="size-3 ml-0.5 opacity-60" />
+                          </a>
+                        ) : (
+                          <button className="p-2 hover:bg-primary/20 text-primary rounded-lg transition-colors opacity-30 cursor-not-allowed" title="No vendor info available" disabled>
+                            <ShoppingCart className="size-5" />
+                          </button>
+                        )
+                      })()}
                       <button className="p-2 hover:bg-surface-container-highest text-[var(--muted-foreground)] rounded-lg transition-colors" title="Edit Item">
                         <Pencil className="size-5" />
                       </button>


### PR DESCRIPTION
## Summary

- Vendor URL registry for 21 lab suppliers (Sigma-Aldrich, Thermo Fisher, Bio-Rad, Addgene, Abcam, Cell Signaling, VWR, McMaster-Carr, etc.)
- Reorder button on inventory table rows opens vendor search page with catalog number pre-filled
- API endpoint `GET /inventory/{id}/reorder-url` for programmatic access
- Falls back to Google search for unrecognized vendors
- Disabled button state for items missing vendor or catalog info

## Test plan

- [x] 81 unit + integration tests covering URL registry, fuzzy matching, edge cases, and API endpoint
- [ ] Manual: verify reorder button appears on hover in inventory table
- [ ] Manual: click reorder on item with known vendor (e.g. Sigma-Aldrich) — opens vendor search page
- [ ] Manual: click reorder on item with unknown vendor — opens Google search
- [ ] Manual: items without vendor/catalog show disabled button

Generated with [Claude Code](https://claude.com/claude-code)