### PR TITLE
fix(ui): remove dark mode, force light theme

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -61,7 +61,6 @@ export default function App() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [alertCount, setAlertCount] = useState(0)
   const [reviewCount, setReviewCount] = useState(0)
-  const [darkMode, setDarkMode] = useState(false)
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const location = useLocation()
@@ -88,21 +87,7 @@ export default function App() {
   useEffect(() => {
     localStorage.removeItem('darkMode')
     document.documentElement.classList.remove('dark')
-    setDarkMode(false)
   }, [])
-
-  const toggleDarkMode = () => {
-    setDarkMode(prev => {
-      const next = !prev
-      localStorage.setItem('darkMode', String(next))
-      if (next) {
-        document.documentElement.classList.add('dark')
-      } else {
-        document.documentElement.classList.remove('dark')
-      }
-      return next
-    })
-  }
 
   useEffect(() => {
     checkAuth()
@@ -157,8 +142,6 @@ export default function App() {
           <Header
             title={PAGE_TITLES[location.pathname] ?? 'Lab Manager'}
             showSearch={location.pathname !== '/ask'}
-            darkMode={darkMode}
-            onToggleDarkMode={toggleDarkMode}
             onMobileMenuToggle={() => setMobileMenuOpen(prev => !prev)}
           />
           <main className="flex-1 overflow-y-auto p-6">

--- a/web/src/__tests__/header.test.tsx
+++ b/web/src/__tests__/header.test.tsx
@@ -8,14 +8,11 @@ import { Header } from '@/components/layout/Header'
 
 const defaultProps = {
   title: 'Dashboard',
-  darkMode: true,
-  onToggleDarkMode: vi.fn(),
   onSearch: vi.fn(),
 }
 
 describe('Header', () => {
   beforeEach(() => {
-    defaultProps.onToggleDarkMode.mockClear()
     defaultProps.onSearch.mockClear()
     vi.useFakeTimers({ shouldAdvanceTime: true })
   })
@@ -104,24 +101,6 @@ describe('Header', () => {
       await vi.advanceTimersByTimeAsync(350)
 
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
-    })
-  })
-
-  describe('AC4: Dark mode toggle works', () => {
-    it('calls onToggleDarkMode when dark mode button is clicked', async () => {
-      vi.useRealTimers()
-      const user = userEvent.setup()
-
-      renderWithProviders(<Header {...defaultProps} />)
-      const toggle = screen.getByLabelText(/switch to light mode/i)
-      await user.click(toggle)
-
-      expect(defaultProps.onToggleDarkMode).toHaveBeenCalledTimes(1)
-    })
-
-    it('shows correct aria-label for light mode state', () => {
-      renderWithProviders(<Header {...defaultProps} darkMode={false} />)
-      expect(screen.getByLabelText(/switch to dark mode/i)).toBeInTheDocument()
     })
   })
 

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -1,17 +1,15 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
-import { Search, Bell, Sun, Moon, Menu } from 'lucide-react'
+import { Search, Bell, Menu } from 'lucide-react'
 import { search } from '@/lib/api'
 
 interface HeaderProps {
   readonly title: string
   readonly onSearch?: (query: string) => void
   readonly showSearch?: boolean
-  readonly darkMode: boolean
-  readonly onToggleDarkMode: () => void
   readonly onMobileMenuToggle?: () => void
 }
 
-export function Header({ title, onSearch, showSearch = true, darkMode, onToggleDarkMode, onMobileMenuToggle }: HeaderProps) {
+export function Header({ title, onSearch, showSearch = true, onMobileMenuToggle }: HeaderProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [suggestions, setSuggestions] = useState<Array<{ type: string; text: string; id: number }>>([])
   const [showSuggestions, setShowSuggestions] = useState(false)
@@ -102,14 +100,6 @@ export function Header({ title, onSearch, showSearch = true, darkMode, onToggleD
       <div className="flex items-center gap-4">
         <button className="flex items-center justify-center rounded-lg size-10 bg-[var(--card)] text-[var(--foreground)] hover:bg-primary/20 transition-colors">
           <Bell className="size-5" />
-        </button>
-        <button
-          onClick={(e) => { e.stopPropagation(); e.preventDefault(); onToggleDarkMode() }}
-          type="button"
-          aria-label={darkMode ? 'Switch to light mode' : 'Switch to dark mode'}
-          className="flex items-center justify-center rounded-lg size-10 bg-[var(--card)] text-[var(--foreground)] hover:bg-primary/20 transition-colors"
-        >
-          {darkMode ? <Sun className="size-5" /> : <Moon className="size-5" />}
         </button>
         <div className="flex items-center gap-3 pl-4 border-l border-primary/10">
           <span className="text-sm font-medium text-[var(--muted-foreground)]">Admin</span>

--- a/web/src/components/ui/ConfidenceBadge.tsx
+++ b/web/src/components/ui/ConfidenceBadge.tsx
@@ -12,7 +12,7 @@ const LEVELS = [
 export function ConfidenceBadge({ confidence }: ConfidenceBadgeProps) {
   if (confidence == null) {
     return (
-      <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium border border-border-dark text-slate-500">
+      <span className="inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium border border-gray-200 text-slate-500">
         —
       </span>
     )

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -5,33 +5,28 @@
 @theme {
   --color-primary: #6C5CE7;
   --color-background-light: #f6f5f8;
-  --color-background-dark: #0B0B14;
-  --color-card-dark: #12121E;
-  --color-sidebar-dark: #12121E;
   --color-accent-green: #00D4AA;
-  --color-surface-dark: #1A1A2E;
-  --color-border-dark: #2A2A3E;
   --color-success: #00D4AA;
   --color-warning: #f59e0b;
   --color-danger: #ef4444;
 
-  /* Stitch Material-3 semantic tokens */
-  --color-on-surface: #F0F0F5;
-  --color-on-surface-variant: #A1A1B5;
-  --color-on-background: #F0F0F5;
-  --color-outline: #2A2A3E;
-  --color-surface-container: #242438;
-  --color-surface-container-high: #2A2A44;
-  --color-surface-container-low: #1E1E36;
-  --color-surface-container-lowest: #16162A;
-  --color-surface-container-highest: #33334D;
-  --color-secondary-container: #4E3B7F;
-  --color-on-secondary-container: #E9DDFF;
+  /* Light-mode semantic tokens */
+  --color-on-surface: #1a1a2e;
+  --color-on-surface-variant: #6b7280;
+  --color-on-background: #1a1a2e;
+  --color-outline: #e5e7eb;
+  --color-surface-container: #f1f3f8;
+  --color-surface-container-high: #e8eaf0;
+  --color-surface-container-low: #f4f5f9;
+  --color-surface-container-lowest: #ffffff;
+  --color-surface-container-highest: #e0e2ea;
+  --color-secondary-container: #ede9ff;
+  --color-on-secondary-container: #4E3B7F;
   --color-primary-container: #6C5CE7;
   --color-tertiary-fixed: #FFDCBE;
   --color-on-tertiary-fixed-variant: #693C00;
-  --color-error-container: #441A1A;
-  --color-error: #FF5555;
+  --color-error-container: #fde8e8;
+  --color-error: #ef4444;
 }
 
 :root {
@@ -72,41 +67,6 @@
   --sidebar-foreground: #1a1a2e;
   --sidebar-border: #e5e7eb;
   --sidebar-accent: #f1f3f8;
-  --sidebar-ring: #6C5CE7;
-}
-
-.dark {
-  --background: #0B0B14;
-  --card: #12121E;
-  --popover: #12121E;
-  --muted: #1A1A2E;
-
-  --foreground: #F0F0F5;
-  --muted-foreground: #8e8ea0;
-
-  --primary: #6C5CE7;
-  --primary-foreground: #ffffff;
-
-  --accent: #00D4AA;
-  --accent-foreground: #ffffff;
-
-  --destructive: #ef4444;
-  --destructive-foreground: #ffffff;
-
-  --warning: #f59e0b;
-  --warning-foreground: #0B0B14;
-
-  --info: #5b8def;
-  --info-foreground: #ffffff;
-
-  --border: #2A2A3E;
-  --input: #2A2A3E;
-  --ring: #6C5CE7;
-
-  --sidebar: #12121E;
-  --sidebar-foreground: #F0F0F5;
-  --sidebar-border: #2A2A3E;
-  --sidebar-accent: #1A1A2E;
   --sidebar-ring: #6C5CE7;
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -25,9 +25,9 @@ class ErrorBoundary extends Component<{ readonly children: ReactNode }, ErrorBou
   render() {
     if (this.state.hasError) {
       return (
-        <div className="flex flex-col items-center justify-center min-h-screen bg-slate-900 text-white p-8">
+        <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 text-gray-900 p-8">
           <h1 className="text-2xl font-bold mb-4">Something went wrong</h1>
-          <p className="text-slate-400 mb-6 text-center max-w-md">
+          <p className="text-gray-500 mb-6 text-center max-w-md">
             {this.state.error?.message ?? 'An unexpected error occurred'}
           </p>
           <button

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -67,9 +67,9 @@ const CONFIDENCE_BUCKETS = [
 function Insight({ text, variant = 'info' }: { text: string; variant?: 'info' | 'warn' | 'good' | 'bad' }) {
   const colors = {
     info: 'bg-primary/5 border-primary/20 text-primary',
-    warn: 'bg-amber-50 dark:bg-amber-500/10 border-amber-200 dark:border-amber-500/20 text-amber-700 dark:text-amber-400',
-    good: 'bg-emerald-50 dark:bg-emerald-500/10 border-emerald-200 dark:border-emerald-500/20 text-emerald-700 dark:text-emerald-400',
-    bad: 'bg-red-50 dark:bg-red-500/10 border-red-200 dark:border-red-500/20 text-red-700 dark:text-red-400',
+    warn: 'bg-amber-50 border-amber-200 text-amber-700',
+    good: 'bg-emerald-50 border-emerald-200 text-emerald-700',
+    bad: 'bg-red-50 border-red-200 text-red-700',
   }
   return (
     <div className={`text-sm font-semibold px-4 py-2.5 rounded-lg border ${colors[variant]}`}>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -239,7 +239,7 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
           {lowStockCount > 0 && (
             <button
               onClick={() => navigate('/inventory')}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 border border-amber-200 dark:border-amber-500/20 hover:bg-amber-100 dark:hover:bg-amber-500/20 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium bg-amber-50 text-amber-700 border border-amber-200 hover:bg-amber-100 transition-colors"
             >
               <AlertTriangle className="size-3.5" />
               {lowStockCount} low stock item{lowStockCount !== 1 ? 's' : ''}
@@ -248,7 +248,7 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
           {expiringCount > 0 && (
             <button
               onClick={() => navigate('/inventory')}
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium bg-orange-50 dark:bg-red-500/10 text-orange-700 dark:text-red-400 border border-orange-200 dark:border-red-500/20 hover:bg-orange-100 dark:hover:bg-red-500/20 transition-colors"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-xl text-xs font-medium bg-orange-50 text-orange-700 border border-orange-200 hover:bg-orange-100 transition-colors"
             >
               <Calendar className="size-3.5" />
               {expiringCount} expiring item{expiringCount !== 1 ? 's' : ''}

--- a/web/src/pages/DocumentsPage.tsx
+++ b/web/src/pages/DocumentsPage.tsx
@@ -100,7 +100,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
   return (
     <div className="space-y-0 -m-6 flex flex-col h-[calc(100vh-4rem)]">
       {/* Top Bar */}
-      <header className="h-16 border-b border-slate-200 dark:border-slate-800 px-8 flex items-center justify-between sticky top-0 bg-white/80 dark:bg-background-dark/80 backdrop-blur-md z-10 shrink-0">
+      <header className="h-16 border-b border-slate-200 px-8 flex items-center justify-between sticky top-0 bg-white/80 backdrop-blur-md z-10 shrink-0">
         <h2 className="text-xl font-bold">Documents</h2>
         <div className="flex items-center gap-4 flex-1 max-w-2xl px-8">
           <div className="relative w-full">
@@ -110,7 +110,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               placeholder="Search vendor or filename..."
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="w-full bg-slate-50 dark:bg-card-dark border border-slate-200 dark:border-slate-700 rounded-lg pl-10 pr-4 py-2 text-sm focus:ring-2 focus:ring-primary focus:border-primary transition-all"
+              className="w-full bg-slate-50 border border-slate-200 rounded-lg pl-10 pr-4 py-2 text-sm focus:ring-2 focus:ring-primary focus:border-primary transition-all"
             />
           </div>
         </div>
@@ -137,7 +137,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               className={
                 isActive
                   ? 'px-4 py-1.5 rounded-full text-sm font-medium bg-primary text-white shadow-lg shadow-primary/20'
-                  : 'px-4 py-1.5 rounded-full text-sm font-medium bg-slate-100 dark:bg-card-dark text-slate-600 dark:text-slate-300 flex items-center gap-2 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors border border-transparent'
+                  : 'px-4 py-1.5 rounded-full text-sm font-medium bg-slate-100 text-slate-600 flex items-center gap-2 hover:bg-slate-200 transition-colors border border-transparent'
               }
             >
               {f.dotClass && !isActive && (
@@ -167,7 +167,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
 
       {/* Table Container */}
       <div className="px-8 pb-8 flex-1 min-h-0 flex flex-col">
-        <div className="bg-white dark:bg-card-dark rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden shadow-sm flex-1 min-h-0">
+        <div className="bg-white rounded-xl border border-slate-200 overflow-hidden shadow-sm flex-1 min-h-0">
           {isLoading ? (
             <div className="flex flex-col items-center justify-center h-64 space-y-3">
               <div className="w-8 h-8 border-2 border-primary/30 border-t-primary rounded-full animate-spin" />
@@ -194,7 +194,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
           ) : (
             <table className="w-full text-left border-collapse">
               <thead>
-                <tr className="bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-800">
+                <tr className="bg-slate-50 border-b border-slate-200">
                   <th className="px-5 py-4 text-xs font-semibold text-slate-500 uppercase tracking-wider">
                     Document
                   </th>
@@ -215,7 +215,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
                   </th>
                 </tr>
               </thead>
-              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+              <tbody className="divide-y divide-slate-100">
                 {filteredDocs.map((doc, idx) => {
                   const badge = statusBadgeClasses(doc.status)
                   const conf = doc.extraction_confidence ?? 0
@@ -223,8 +223,8 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
                   return (
                     <tr
                       key={doc.id}
-                      className={`hover:bg-primary/[0.03] dark:hover:bg-slate-800/30 transition-colors duration-150 cursor-pointer group ${
-                        idx % 2 === 1 ? 'bg-slate-50/40 dark:bg-white/[0.01]' : 'bg-white'
+                      className={`hover:bg-primary/[0.03] transition-colors duration-150 cursor-pointer group ${
+                        idx % 2 === 1 ? 'bg-slate-50/40' : 'bg-white'
                       }`}
                       onClick={() => navigate(`/review?id=${doc.id}`)}
                     >
@@ -246,10 +246,10 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
                           </div>
                         </div>
                       </td>
-                      <td className="px-5 py-4 text-sm text-slate-600 dark:text-slate-400">
+                      <td className="px-5 py-4 text-sm text-slate-600">
                         {doc.vendor_name ?? 'Unknown'}
                       </td>
-                      <td className="px-5 py-4 text-sm text-slate-600 dark:text-slate-400 max-w-[140px] whitespace-nowrap overflow-hidden text-ellipsis">
+                      <td className="px-5 py-4 text-sm text-slate-600 max-w-[140px] whitespace-nowrap overflow-hidden text-ellipsis">
                         {doc.document_type ? formatEnum(doc.document_type) : '--'}
                       </td>
                       <td className="px-5 py-4">
@@ -258,7 +258,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
                       <td className="px-5 py-4">
                         {doc.extraction_confidence != null ? (
                           <div className="flex items-center gap-3">
-                            <div className="w-20 bg-slate-100 dark:bg-slate-700 h-2 rounded-full overflow-hidden">
+                            <div className="w-20 bg-slate-100 h-2 rounded-full overflow-hidden">
                               <div
                                 className={`${confidenceBarColor(conf)} h-full rounded-full transition-all`}
                                 style={{ width: `${confPct}%` }}
@@ -288,15 +288,15 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
           <div className="mt-6 flex items-center justify-between">
             <p className="text-sm text-slate-500">
               Showing{' '}
-              <span className="font-semibold text-slate-900 dark:text-slate-200">
+              <span className="font-semibold text-slate-900">
                 {startItem}
               </span>{' '}
               to{' '}
-              <span className="font-semibold text-slate-900 dark:text-slate-200">
+              <span className="font-semibold text-slate-900">
                 {endItem}
               </span>{' '}
               of{' '}
-              <span className="font-semibold text-slate-900 dark:text-slate-200">
+              <span className="font-semibold text-slate-900">
                 {total}
               </span>{' '}
               documents
@@ -305,7 +305,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               <button
                 onClick={() => setPage((p) => Math.max(1, p - 1))}
                 disabled={page <= 1}
-                className="flex items-center justify-center w-10 h-10 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-card-dark text-slate-400 hover:text-primary hover:border-primary/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center justify-center w-10 h-10 rounded-lg border border-slate-200 bg-white text-slate-400 hover:text-primary hover:border-primary/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Previous page"
               >
                 <ChevronLeft />
@@ -313,7 +313,7 @@ export function DocumentsPage({ onError }: DocumentsPageProps) {
               <button
                 onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
                 disabled={page >= totalPages}
-                className="flex items-center justify-center w-10 h-10 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-card-dark text-slate-400 hover:text-primary hover:border-primary/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center justify-center w-10 h-10 rounded-lg border border-slate-200 bg-white text-slate-400 hover:text-primary hover:border-primary/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
                 aria-label="Next page"
               >
                 <ChevronRight />

--- a/web/src/pages/OrdersPage.tsx
+++ b/web/src/pages/OrdersPage.tsx
@@ -97,8 +97,8 @@ export function OrdersPage({ onError }: OrdersPageProps) {
       <div>
         <div className="flex justify-between items-end">
           <div>
-            <h2 className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight">Orders</h2>
-            <p className="text-gray-500 dark:text-gray-400 mt-2 text-sm">
+            <h2 className="text-3xl font-bold text-gray-900 tracking-tight">Orders</h2>
+            <p className="text-gray-500 mt-2 text-sm">
               {allOrders.length > 0
                 ? `${activeCount} active, ${allOrders.length - activeCount} completed across ${allOrders.length} total orders.`
                 : 'No orders yet. Orders are created when documents are processed.'}

--- a/web/src/pages/ReviewPage.tsx
+++ b/web/src/pages/ReviewPage.tsx
@@ -34,16 +34,16 @@ function confBadgeClasses(confidence?: number): {
   if (c >= 0.8)
     return {
       wrapperClass:
-        'bg-emerald-50 dark:bg-emerald-500/20 text-emerald-600 dark:text-emerald-400 text-xs font-bold px-2 py-1 rounded border border-emerald-200 dark:border-emerald-500/30',
+        'bg-emerald-50 text-emerald-600 text-xs font-bold px-2 py-1 rounded border border-emerald-200',
     }
   if (c >= 0.6)
     return {
       wrapperClass:
-        'bg-amber-50 dark:bg-amber-500/20 text-amber-600 dark:text-amber-500 text-xs font-bold px-2 py-1 rounded border border-amber-200 dark:border-amber-500/30',
+        'bg-amber-50 text-amber-600 text-xs font-bold px-2 py-1 rounded border border-amber-200',
     }
   return {
     wrapperClass:
-      'bg-red-50 dark:bg-red-500/20 text-red-600 dark:text-red-500 text-xs font-bold px-2 py-1 rounded border border-red-200 dark:border-red-500/30',
+      'bg-red-50 text-red-600 text-xs font-bold px-2 py-1 rounded border border-red-200',
   }
 }
 
@@ -190,7 +190,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                   }}
                   className={
                     isSelected
-                      ? 'p-4 rounded-xl border border-[var(--border)] border-l-4 border-l-primary bg-purple-50 dark:bg-purple-900/20 cursor-pointer relative group'
+                      ? 'p-4 rounded-xl border border-[var(--border)] border-l-4 border-l-primary bg-purple-50 cursor-pointer relative group'
                       : 'p-4 rounded-xl border border-[var(--border)] bg-[var(--card)]/50 hover:bg-[var(--card)] cursor-pointer transition-all'
                   }
                 >
@@ -444,7 +444,7 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                         </th>
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-border-dark text-[var(--foreground)]">
+                    <tbody className="divide-y divide-gray-200 text-[var(--foreground)]">
                       {docDetail.extracted_data?.items && docDetail.extracted_data.items.length > 0 ? (
                         docDetail.extracted_data.items.map((item, idx) => (
                           <tr key={idx} className="hover:bg-primary/5 transition-colors">

--- a/web/src/pages/SetupPage.tsx
+++ b/web/src/pages/SetupPage.tsx
@@ -28,18 +28,18 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
   }
 
   return (
-    <div className="bg-background-light dark:bg-background-dark font-[Inter,sans-serif] antialiased flex items-center justify-center min-h-screen p-4">
+    <div className="bg-background-light font-[Inter,sans-serif] antialiased flex items-center justify-center min-h-screen p-4">
       {/* Setup Wizard Card */}
-      <div className="w-full max-w-[440px] bg-white dark:bg-card-dark border border-slate-200 dark:border-[#2d2d44] rounded-xl shadow-2xl p-8 md:p-10">
+      <div className="w-full max-w-[440px] bg-white border border-slate-200 rounded-xl shadow-2xl p-8 md:p-10">
         {/* Icon Header */}
         <div className="flex flex-col items-center mb-8">
           <div className="w-16 h-16 bg-primary/20 rounded-full flex items-center justify-center mb-6">
             <FlaskConical className="text-primary size-10" />
           </div>
-          <h1 className="text-slate-900 dark:text-slate-100 text-3xl font-bold tracking-tight text-center mb-2">
+          <h1 className="text-slate-900 text-3xl font-bold tracking-tight text-center mb-2">
             Welcome to LabClaw
           </h1>
-          <p className="text-slate-500 dark:text-slate-400 text-sm font-medium text-center">
+          <p className="text-slate-500 text-sm font-medium text-center">
             Set up your lab in 30 seconds
           </p>
         </div>
@@ -55,7 +55,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
         <form onSubmit={handleSubmit} className="space-y-5">
           {/* Name Input */}
           <div className="space-y-2">
-            <label htmlFor="setup-name" className="text-slate-700 dark:text-slate-300 text-sm font-semibold ml-1">Your Name</label>
+            <label htmlFor="setup-name" className="text-slate-700 text-sm font-semibold ml-1">Your Name</label>
             <div className="relative">
               <User className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 size-5" />
               <input
@@ -63,7 +63,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 dark:bg-background-dark/50 border border-slate-200 dark:border-[#2d2d44] rounded-lg text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
+                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 border border-slate-200 rounded-lg text-slate-900 placeholder:text-slate-400 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
                 placeholder="John Doe"
                 required
                 autoFocus
@@ -73,7 +73,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
 
           {/* Email Input */}
           <div className="space-y-2">
-            <label htmlFor="setup-email" className="text-slate-700 dark:text-slate-300 text-sm font-semibold ml-1">Email</label>
+            <label htmlFor="setup-email" className="text-slate-700 text-sm font-semibold ml-1">Email</label>
             <div className="relative">
               <Mail className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 size-5" />
               <input
@@ -81,7 +81,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 dark:bg-background-dark/50 border border-slate-200 dark:border-[#2d2d44] rounded-lg text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
+                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 border border-slate-200 rounded-lg text-slate-900 placeholder:text-slate-400 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
                 placeholder="name@lab.com"
                 required
               />
@@ -90,7 +90,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
 
           {/* Password Input */}
           <div className="space-y-2">
-            <label htmlFor="setup-password" className="text-slate-700 dark:text-slate-300 text-sm font-semibold ml-1">Password</label>
+            <label htmlFor="setup-password" className="text-slate-700 text-sm font-semibold ml-1">Password</label>
             <div className="relative">
               <Lock className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 size-5" />
               <input
@@ -98,7 +98,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 dark:bg-background-dark/50 border border-slate-200 dark:border-[#2d2d44] rounded-lg text-slate-900 dark:text-slate-100 placeholder:text-slate-400 dark:placeholder:text-slate-500 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
+                className="w-full pl-11 pr-4 py-3.5 bg-slate-50 border border-slate-200 rounded-lg text-slate-900 placeholder:text-slate-400 focus:ring-2 focus:ring-primary/50 focus:border-primary outline-none transition-all"
                 placeholder="........"
                 required
               />
@@ -110,7 +110,7 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
             <button
               type="submit"
               disabled={loading}
-              className="w-full py-4 bg-accent-green hover:bg-[#05c491] text-background-dark font-bold rounded-lg shadow-lg shadow-accent-green/20 transition-all active:scale-[0.98] flex items-center justify-center gap-2 disabled:opacity-60"
+              className="w-full py-4 bg-accent-green hover:bg-[#05c491] text-white font-bold rounded-lg shadow-lg shadow-accent-green/20 transition-all active:scale-[0.98] flex items-center justify-center gap-2 disabled:opacity-60"
             >
               {loading ? (
                 <>
@@ -128,9 +128,9 @@ export function SetupPage({ onComplete }: Readonly_SetupPageProps) {
         </form>
 
         {/* Footer Info */}
-        <div className="mt-8 pt-6 border-t border-slate-200 dark:border-[#2d2d44] flex items-center justify-center gap-2">
+        <div className="mt-8 pt-6 border-t border-slate-200 flex items-center justify-center gap-2">
           <Info className="text-slate-400 size-5" />
-          <p className="text-slate-500 dark:text-slate-400 text-[11px] uppercase tracking-wider font-semibold">
+          <p className="text-slate-500 text-[11px] uppercase tracking-wider font-semibold">
             You can add more team members after setup
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Removed all `dark:` utility classes from every .tsx file (7 page files + components)
- Removed dark mode toggle button from Header, darkMode state from App
- Removed `.dark` CSS variable block from index.css
- Updated Material-3 semantic tokens (`on-surface`, `surface-container`, etc.) to light-mode values
- Fixed broken references to removed dark tokens (`border-dark`, `background-dark`, `card-dark`)
- Fixed error boundary in main.tsx to use light background

## Test plan
- [x] Build passes (`npm run build`)
- [x] No new test regressions (17 pre-existing failures, same as main)
- [x] Deployed to demo.labclaw.org container
- [ ] Visually verify all pages render in light mode only
- [ ] Confirm no dark elements remain on any page

Generated with Claude Code