### PR TITLE
chore: GitHub automation — dependabot, templates, labels, stale bot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default owners
+* @labclaw/core-team
+
+# Frontend
+/web/ @labclaw/frontend
+
+# CI/CD
+/.github/ @labclaw/devops
+
+# Security-sensitive
+/src/lab_manager/api/app.py @labclaw/security
+/src/lab_manager/config.py @labclaw/security

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Lab Manager
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- Lab Manager version: [e.g. 0.1.8]
+- Deployment: [Docker / local dev]
+- Browser: [e.g. Chrome 130]
+- OS: [e.g. Ubuntu 24.04]
+
+## Screenshots / Logs
+
+If applicable, add screenshots or paste relevant log output.
+
+```
+paste logs here
+```
+
+## Additional Context
+
+Any other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/labclaw/lab-manager#readme
+    about: Check the README for setup and usage instructions.
+  - name: Discussions
+    url: https://github.com/labclaw/lab-manager/discussions
+    about: Ask questions and share ideas in GitHub Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for Lab Manager
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+A clear description of the problem this feature would solve.
+
+## Proposed Solution
+
+Describe the solution you'd like.
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Any other context, mockups, or examples.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,51 @@
 version: 2
 updates:
+  # Python dependencies
   - package-ecosystem: pip
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - python
     commit-message:
       prefix: "chore(deps):"
 
+  # GitHub Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
     commit-message:
       prefix: "ci(deps):"
+
+  # npm (frontend)
+  - package-ecosystem: npm
+    directory: "/web"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - frontend
+    commit-message:
+      prefix: "chore(deps):"
+
+  # Docker
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: "chore(deps):"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,25 @@
+python:
+  - changed-files:
+      - any-glob-to-any-file: "src/**/*.py"
+
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: "web/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ".github/**"
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "uv.lock"
+          - "web/package.json"
+          - "web/package-lock.json"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "*.md"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do? One or two sentences. -->
+
+## Changes
+
+<!-- Bullet list of what changed. -->
+
+-
+
+## Test Plan
+
+<!-- How was this tested? -->
+
+- [ ] Unit tests pass (`uv run pytest tests --ignore=tests/bdd -q`)
+- [ ] Linting passes (`uv run ruff check src/ tests/`)
+- [ ] Type check passes (`uv run mypy src/lab_manager/`)
+- [ ] Release gate passes (`bash scripts/run_release_gate.sh`)
+
+## Screenshots
+
+<!-- If applicable, add screenshots or screen recordings. -->

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Stale
+
+on:
+  schedule:
+    - cron: "0 0 * * 0" # weekly on Sunday
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs.
+          stale-pr-message: >
+            This PR has been automatically marked as stale because it has not
+            had recent activity.
+          days-before-stale: 30
+          days-before-close: 14
+          stale-issue-label: stale
+          stale-pr-label: stale

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Lab Manager
 
+[![CI](https://github.com/labclaw/lab-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/labclaw/lab-manager/actions/workflows/ci.yml)
+[![Security](https://github.com/labclaw/lab-manager/actions/workflows/security.yml/badge.svg)](https://github.com/labclaw/lab-manager/actions/workflows/security.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
+[![Version](https://img.shields.io/badge/version-0.1.8.2-green.svg)](https://github.com/labclaw/lab-manager/releases)
+
 Lab Manager is a lab operations app for research groups that need one place to receive supplies, review scanned documents, track inventory, and keep an audit trail.
 
 Core flow:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,11 @@ filterwarnings = [
   "ignore::DeprecationWarning:sqlmodel.*",
   "ignore::pytest.PytestUnknownMarkWarning",
 ]
+
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.1.8.2"
+version_files = ["pyproject.toml:version"]
+tag_format = "v$version"
+changelog_file = "CHANGELOG.md"
+update_changelog_on_bump = true


### PR DESCRIPTION
## Summary

- Professional GitHub repo setup for public-facing open-source project
- Adds all standard automation expected of top-tier OSS projects (FastAPI, Pydantic level)

## Changes

- **Dependabot** (`dependabot.yml`): expanded from pip+actions to include npm (web/) and Docker, added labels, schedule day (Monday), PR limits
- **Issue templates**: bug report, feature request, template chooser (disables blank issues, links to docs/discussions)
- **PR template**: summary, changes, test plan checklist, screenshots section
- **Auto-labeler** (`labeler.yml` + workflow): labels PRs based on changed files (python, frontend, ci, dependencies, documentation)
- **Stale bot** (`stale.yml`): marks inactive issues/PRs after 30 days, closes after 14 more
- **CODEOWNERS**: routes reviews to core-team, frontend, devops, security teams
- **Commitizen** (`pyproject.toml`): configured for conventional commits version bumping
- **README badges**: CI, Security, License, Python version, Version
- **GitHub labels**: 15 standard labels created (bug, feature, enhancement, documentation, dependencies, ci, security, frontend, python, good first issue, help wanted, breaking change, performance, docker, stale)

## Test Plan

- [x] No production code changed — CI/templates/config only
- [x] Labels created successfully via `gh label create`
- [x] All YAML files use valid syntax
- [x] Existing release workflow untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)