### PR TITLE
docs: analyze cross-platform support feasibility and necessity

### DIFF
--- a/docs/platform-support-analysis.md
+++ b/docs/platform-support-analysis.md
@@ -1,0 +1,205 @@
+# Lab Manager 全平台支持分析
+
+> 分析日期: 2026-03-25
+> 范围: labclaw/lab-manager 作为核心入口（但非唯一入口）的全平台支持可行性与必要性
+
+---
+
+## 1. 现状评估
+
+### 1.1 当前平台支持矩阵
+
+| 平台 | 服务端部署 | 本地开发 | 终端用户访问 |
+|------|-----------|---------|-------------|
+| Linux (Ubuntu/Debian) | **完整支持** — Docker Compose + install.sh | **完整支持** — uv + Docker | Web 浏览器 |
+| Linux (其他发行版) | **部分支持** — Docker 可用但 install.sh 有警告 | 同上 | Web 浏览器 |
+| macOS | **可行** — Docker Desktop | **完整支持** — uv + Docker Desktop | Web 浏览器 |
+| Windows | **不支持** — 无 .bat/.ps1 脚本 | **需 WSL2** — bash 脚本不兼容原生 Windows | Web 浏览器 |
+| iOS / Android | 不适用 | 不适用 | **部分** — 无 PWA 离线支持, 非响应式优化 |
+| Cloud PaaS | **未适配** — 无 Heroku/Railway/Fly.io 配置 | 不适用 | Web 浏览器 |
+
+### 1.2 架构特征
+
+- **服务端**: Docker Compose 单机部署 (PostgreSQL 17 + Meilisearch + FastAPI + Caddy)
+- **前端**: React 19 SPA (Vite + Tailwind), 通过 Caddy 反代提供服务
+- **部署脚本**: 纯 bash, 依赖 `/proc/meminfo`, `systemctl`, `apt-get` 等 Linux 特有工具
+- **C 扩展依赖**: psycopg[binary], bcrypt, pillow, cryptography — 需要平台特定的编译轮子
+- **AI 管道**: 调用外部 CLI 工具 (claude, gemini, codex) 和 HTTP API, 与平台无关
+
+### 1.3 核心入口定义
+
+Lab Manager 作为 **核心入口** 意味着:
+- 它是实验室日常运营的主要数据通道 (库存、订单、供应商、文档)
+- 但 **非唯一入口** — 数据还可通过 API 集成、批量导入脚本、SQLAdmin 面板进入
+- 因此平台支持策略应围绕 **可靠访问** 而非 **无处不在**
+
+---
+
+## 2. 全平台支持维度分析
+
+### 2.1 服务端部署平台
+
+#### 现状: Linux 单平台, Docker 化
+
+**可行性: 高 (已基本实现)**
+
+Docker Compose 已经提供了跨平台部署的抽象层。实际瓶颈不在应用代码, 而在部署自动化脚本:
+
+| 改造项 | 工作量 | 收益 |
+|--------|--------|------|
+| macOS Docker Desktop 支持 | 低 — 移除 `systemctl`/`apt-get` 依赖, 检测 Docker Desktop | 开发者本地部署 |
+| Windows Docker Desktop 支持 | 中 — 需要 PowerShell 版 install.ps1 或 WSL2 引导 | 企业 IT 环境 |
+| Cloud PaaS 适配 (Fly.io / Railway) | 中 — 需拆分服务, 添加 managed PG/search 配置 | 零运维部署 |
+| Kubernetes Helm Chart | 高 — 需要 StatefulSet、PVC、Secret 管理 | 企业级扩展 |
+
+**必要性: 低→中**
+
+实验室服务器典型环境就是 Linux. macOS 开发支持已通过 Docker Desktop 隐式存在. K8s/PaaS 只在规模化时才需要.
+
+**建议**: 不需要主动扩展。当前 Docker Compose + Linux 覆盖了 95% 的目标部署场景。
+
+---
+
+### 2.2 本地开发环境
+
+#### 现状: Linux/macOS 原生, Windows 需 WSL2
+
+**可行性: 高**
+
+Python 生态本身是跨平台的。主要障碍:
+
+1. **Shell 脚本** (`bootstrap_local_env.sh`, `deploy.sh` 等) — 无 Windows 原生等价物
+2. **testcontainers** — 需要 Docker, Windows 上需要 Docker Desktop 或 WSL2 后端
+3. **C 扩展** — `psycopg[binary]`, `bcrypt`, `pillow` 均提供 Windows wheel, 无阻碍
+4. **路径分隔符** — 代码中未发现硬编码 `/` 路径问题 (使用 `pathlib` 或配置注入)
+
+**必要性: 低**
+
+- 当前团队使用 Linux/macOS 开发
+- WSL2 是 Windows 开发者的标准方案, 无额外适配成本
+- 添加 PowerShell 脚本会增加维护负担却收益有限
+
+**建议**: 维持现状。在 `deploy/README.md` 中补充 Windows (WSL2) 说明即可。
+
+---
+
+### 2.3 终端用户访问平台 (重点)
+
+#### 现状: Web SPA, 桌面浏览器优先
+
+这是 **全平台支持最有价值** 的维度, 因为终端用户 (实验室人员) 不关心服务器运行在哪里, 只关心能否用自己的设备访问。
+
+#### 2.3.1 桌面浏览器 (Chrome / Firefox / Safari / Edge)
+
+**现状: 完整支持** — React SPA 通过标准 HTTP 提供, 无浏览器特定 API 依赖。
+
+无需改动。
+
+#### 2.3.2 移动端浏览器
+
+**可行性: 高**
+
+当前前端使用 Tailwind CSS, 具备响应式基础, 但未做移动端专项优化:
+
+| 改造项 | 工作量 | 收益 |
+|--------|--------|------|
+| 响应式布局审查与修复 | 低-中 | 实验室人员可在手机上查看库存/审批 |
+| 触控交互优化 (按钮尺寸、手势) | 低 | 移动端可用性提升 |
+| PWA 支持 (manifest.json + service worker) | 低 — 已有 `manifest.json` 和 `sw.js` 骨架 | 添加到主屏、基础离线提示 |
+| 离线数据缓存 | 高 | 无网环境下只读访问 |
+
+**必要性: 中→高**
+
+实验室场景中, 人员经常需要在实验台旁 (离开电脑) 查看库存量、扫描入库、审批文档。移动端是真实的使用场景。
+
+**建议**: 优先做响应式布局 + PWA 基础支持, 这是投入产出比最高的全平台改进。
+
+#### 2.3.3 原生移动 App (iOS / Android)
+
+**可行性: 中**
+
+| 方案 | 工作量 | 优势 | 劣势 |
+|------|--------|------|------|
+| React Native 重写 | 极高 | 原生体验 | 双份代码维护 |
+| Capacitor / Ionic 包装 | 中 | 复用 React SPA | 非原生体验, 额外构建流程 |
+| PWA (推荐) | 低 | 零额外代码, 浏览器即入口 | 无推送通知 (iOS 限制)、无硬件深度集成 |
+
+**必要性: 低**
+
+- 实验室管理不需要推送通知、相机深度集成等原生能力
+- PWA 在 2026 年已覆盖绝大多数移动端需求 (包括 iOS Safari PWA 支持)
+- 原生 App 的维护成本与发布审核流程不值得当前阶段投入
+
+**建议**: 不做原生 App。PWA 即可满足移动端需求。
+
+#### 2.3.4 桌面原生 App (Electron / Tauri)
+
+**可行性: 中**
+
+**必要性: 极低**
+
+- Web 应用已是最佳桌面入口, 无需包装
+- 不存在需要系统级权限的桌面功能 (文件系统、硬件)
+- 文档扫描由独立设备完成, 不需要桌面 App 集成
+
+**建议**: 不做。
+
+---
+
+### 2.4 API 集成平台
+
+#### 现状: 82 个 RESTful API 端点 + X-Api-Key 认证
+
+**可行性: 已实现**
+
+当前 API 设计良好, 支持任何能发 HTTP 请求的平台集成:
+- LIMS 系统对接
+- ERP 数据同步
+- 自动化脚本 (Python, cURL, 任何语言)
+- Zapier / Make / n8n 等低代码平台
+
+**建议**: 补充 OpenAPI schema 导出 (`/openapi.json` 已由 FastAPI 自动生成), 考虑发布 SDK (Python client) 降低集成门槛。
+
+---
+
+## 3. 优先级矩阵
+
+| 优先级 | 方向 | 投入 | 预期收益 | 建议 |
+|--------|------|------|---------|------|
+| **P0** | 移动端响应式 + PWA | 1-2 周 | 实验室人员随时随地访问 | **立即做** |
+| **P1** | API 文档 + Python SDK | 1 周 | 降低系统集成门槛 | **近期做** |
+| **P2** | macOS 部署文档 | 1-2 天 | 开发者体验 | 补充文档即可 |
+| **P3** | Cloud PaaS 适配 | 2-3 周 | 零运维部署选项 | 有需求时做 |
+| **P4** | Windows 开发支持 | 1 周 | 扩大开发者基础 | WSL2 文档即可 |
+| **P5** | Kubernetes 部署 | 4-6 周 | 企业级扩展 | 当前不需要 |
+| ~~P?~~ | 原生移动/桌面 App | 8+ 周 | 极低 — PWA 已覆盖 | **不做** |
+
+---
+
+## 4. 结论
+
+### 核心判断
+
+**Lab Manager 不需要 "全平台支持"，需要 "全场景可达"。**
+
+区别在于:
+- **全平台支持** = 为每个 OS/设备编写原生客户端 → 维护成本爆炸, 不适合小团队
+- **全场景可达** = 确保用户在任何设备上都能完成关键操作 → Web + 响应式 + PWA 即可
+
+### 架构优势
+
+当前架构 (Docker + Web SPA + REST API) 天然具备跨平台能力:
+1. **服务端**: Docker 消除了平台差异, 一次构建随处部署
+2. **前端**: 浏览器是最好的跨平台运行时, React SPA 自动覆盖所有主流 OS
+3. **集成**: RESTful API 是最通用的系统间通信协议
+
+### 唯一短板
+
+移动端体验。这不是技术限制, 而是还没做响应式优化。鉴于实验室场景的移动端需求真实存在, 这是最值得投入的方向。
+
+### 行动建议
+
+1. **做**: 移动端响应式 + PWA — 唯一有实际收益的 "平台扩展"
+2. **补**: 文档 (macOS 开发、Windows WSL2、API 集成指南)
+3. **不做**: 原生 App、Electron、K8s — 投入产出比不合理
+4. **观察**: Cloud PaaS 适配 — 等用户需求明确后再投入


### PR DESCRIPTION
## Summary

- Add `docs/platform-support-analysis.md` — comprehensive cross-platform support analysis for Lab Manager as the core (but not sole) entry point
- Evaluates 4 dimensions: server deployment, developer environment, end-user access, API integration
- Covers 6 platform targets: Linux, macOS, Windows, iOS/Android, Cloud PaaS, Kubernetes
- Each target assessed on feasibility, necessity, effort, and ROI

## Key Findings

**核心结论: Lab Manager 不需要 "全平台支持"，需要 "全场景可达"。**

Current Docker + Web SPA + REST API architecture already provides cross-platform reach. The analysis identifies one meaningful gap and recommends against over-engineering:

| Priority | Direction | Effort | Recommendation |
|----------|-----------|--------|---------------|
| **P0** | Mobile responsive + PWA | 1-2 wk | **Do now** — real lab use case (bench-side inventory check, approval) |
| **P1** | API docs + Python SDK | 1 wk | **Near term** — OpenAPI already auto-generated, publish client SDK |
| **P2** | macOS/Windows dev docs | 1-2 d | Documentation only — WSL2 is standard for Windows devs |
| **P3** | Cloud PaaS (Fly.io/Railway) | 2-3 wk | When demand materializes |
| **P4** | Kubernetes Helm Chart | 4-6 wk | Not needed at current scale |
| **N/A** | Native mobile/desktop apps | 8+ wk | **Don't do** — PWA covers mobile; Electron adds no value |

### Evidence from codebase audit

- `deploy/install.sh`: targets Ubuntu/Debian only (`/etc/os-release`, `apt-get`, `systemctl`)
- `docker-compose.yml`: platform-agnostic via Docker, but automation scripts are bash-only
- `web/`: React 19 + Tailwind CSS — responsive foundation exists, but no mobile-specific optimization
- `src/lab_manager/static/manifest.json` + `sw.js`: PWA skeleton already present
- `src/lab_manager/config.py`: no hardcoded paths, uses env vars — portable
- C extensions (`psycopg[binary]`, `bcrypt`, `pillow`): all provide pre-built wheels for Linux/macOS/Windows
- 15 bash scripts, 0 PowerShell/batch scripts — no native Windows automation

## Scope

This PR adds **analysis only** (single .md file). No code changes, no behavior changes.

## Test plan

- [x] Document renders correctly in GitHub markdown (tables, headers, formatting)
- [x] No code changes — lint, typecheck, tests unaffected
- [x] Commit follows conventional commits format (`docs:` prefix)
- [x] Rebased on latest `main` (a3451da)

https://claude.ai/code/session_01H7NXbaVs43PN7p1DNcYTwm