### PR TITLE
fix(security): sanitize test fixtures and pin CI action SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Build Docker image (no push)
-        uses: docker/build-push-action@v6.13.0
+        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,6 +11,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not

--- a/tests/bdd/features/one_click_setup.feature
+++ b/tests/bdd/features/one_click_setup.feature
@@ -39,32 +39,32 @@ Feature: One-Click Lab Setup
 
   Scenario: Create admin account via setup wizard
     Given a fresh Lab Manager instance with no users
-    When I complete setup with name "Dr. Chen" email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    When I complete setup with name "Dr. Chen" email "admin@example.com" and password "testpassword123"
     Then the setup should succeed
     And the setup status should no longer indicate setup is needed
 
   Scenario: Setup endpoint requires no authentication
     Given a fresh Lab Manager instance with no users
-    When I complete setup with name "Dr. Chen" email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    When I complete setup with name "Dr. Chen" email "admin@example.com" and password "testpassword123"
     Then I should not receive a 401 unauthorized error
 
   # === Input validation ===
 
   Scenario: Invalid email is rejected
     Given a fresh Lab Manager instance with no users
-    When I complete setup with name "Dr. Chen" email "notanemail" and password "neuroscience2026"
+    When I complete setup with name "Dr. Chen" email "notanemail" and password "testpassword123"
     Then the setup should fail with status 422
     And the error should mention "Invalid email"
 
   Scenario: Empty name is rejected
     Given a fresh Lab Manager instance with no users
-    When I complete setup with name "   " email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    When I complete setup with name "   " email "admin@example.com" and password "testpassword123"
     Then the setup should fail with status 422
     And the error should mention "Name must be"
 
   Scenario: Password too short is rejected
     Given a fresh Lab Manager instance with no users
-    When I complete setup with name "Dr. Chen" email "chen@mgh.harvard.edu" and password "short"
+    When I complete setup with name "Dr. Chen" email "admin@example.com" and password "short"
     Then the setup should fail with status 422
     And the error should mention "at least 8 characters"
 
@@ -90,32 +90,32 @@ Feature: One-Click Lab Setup
   # === Login flow ===
 
   Scenario: Login works immediately after setup
-    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "chen@mgh.harvard.edu" and password "neuroscience2026"
-    When I log in with email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "admin@example.com" and password "testpassword123"
+    When I log in with email "admin@example.com" and password "testpassword123"
     Then the login should succeed
     And the logged-in user name should be "Dr. Chen"
 
   Scenario: Login with wrong password fails
-    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "chen@mgh.harvard.edu" and password "neuroscience2026"
-    When I log in with email "chen@mgh.harvard.edu" and password "wrongpassword"
+    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "admin@example.com" and password "testpassword123"
+    When I log in with email "admin@example.com" and password "wrongpassword"
     Then the login should fail with status 401
 
   Scenario: Session cookie is set after login
-    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "chen@mgh.harvard.edu" and password "neuroscience2026"
-    When I log in with email "chen@mgh.harvard.edu" and password "neuroscience2026"
+    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "admin@example.com" and password "testpassword123"
+    When I log in with email "admin@example.com" and password "testpassword123"
     Then a session cookie should be set
 
   Scenario: Authenticated user can access protected endpoints
-    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "chen@mgh.harvard.edu" and password "neuroscience2026"
-    And I am logged in as "chen@mgh.harvard.edu" with password "neuroscience2026"
+    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "admin@example.com" and password "testpassword123"
+    And I am logged in as "admin@example.com" with password "testpassword123"
     When I check my auth status
     Then I should be recognized as "Dr. Chen"
 
   # === Logout ===
 
   Scenario: Logout clears session
-    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "chen@mgh.harvard.edu" and password "neuroscience2026"
-    And I am logged in as "chen@mgh.harvard.edu" with password "neuroscience2026"
+    Given a Lab Manager instance where setup was completed by "Dr. Chen" with email "admin@example.com" and password "testpassword123"
+    And I am logged in as "admin@example.com" with password "testpassword123"
     When I log out
     Then the logout should succeed
     And checking my auth status should return 401

--- a/tests/bdd/step_defs/test_one_click_setup.py
+++ b/tests/bdd/step_defs/test_one_click_setup.py
@@ -298,7 +298,7 @@ def complete_setup_long_password(api, ctx):
         "/api/v1/setup/complete",
         json={
             "admin_name": "Dr. Chen",
-            "admin_email": "chen@mgh.harvard.edu",
+            "admin_email": "admin@example.com",
             "admin_password": long_password,
         },
     )


### PR DESCRIPTION
## Summary
- Replace `chen@mgh.harvard.edu` with `admin@example.com` in BDD tests (public repo exposure)
- Replace real password `neuroscience2026` with `testpassword123` in BDD test fixtures
- Pin 3 GitHub Actions to SHA (`docker/build-push-action`, `actions/labeler`, `actions/stale`)

## Test plan
- [ ] CI passes
- [ ] No institution-specific references remain in tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)