### PR TITLE
fix(ci): add retry loop to Docker publish verify step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,5 +73,12 @@ jobs:
 
       - name: Verify image
         run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}
+          # GHCR needs time to propagate the manifest after push
+          for i in 1 2 3; do
+            if docker pull ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }}; then
+              break
+            fi
+            echo "Attempt $i: manifest not ready, waiting 10s..."
+            sleep 10
+          done
           docker run --rm --entrypoint /app/.venv/bin/python ghcr.io/${{ github.repository }}:${{ steps.version.outputs.tag }} -c "import lab_manager; print('OK')"


### PR DESCRIPTION
## Summary
- GHCR manifest propagation can lag behind push, causing verify to fail with `manifest unknown`
- Add 3 retries with 10s delay before `docker pull` in publish workflow
- Fixes the v0.1.9 Docker publish failure

## Test plan
- [ ] CI passes
- [ ] Next tag push should publish Docker image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)