### PR TITLE
feat(intake): email-to-intake agent for vendor email processing

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -647,6 +647,7 @@ def create_app() -> FastAPI:
         ask,
         audit,
         documents,
+        email_ingest,
         equipment,
         export,
         inventory,
@@ -685,6 +686,9 @@ def create_app() -> FastAPI:
     api_router.include_router(alerts.router, prefix="/api/v1/alerts", tags=["alerts"])
     api_router.include_router(
         telemetry.router, prefix="/api/v1/telemetry", tags=["telemetry"]
+    )
+    api_router.include_router(
+        email_ingest.router, prefix="/api/v1/email", tags=["email"]
     )
     app.include_router(api_router)
 

--- a/src/lab_manager/api/routes/email_ingest.py
+++ b/src/lab_manager/api/routes/email_ingest.py
@@ -1,0 +1,150 @@
+"""Email intake API endpoints."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, BackgroundTasks, Depends, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from lab_manager.api.deps import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+# Max raw MIME email size: 50 MB
+_MAX_RAW_EMAIL_BYTES = 50 * 1024 * 1024
+
+
+class EmailAttachmentPayload(BaseModel):
+    """A single email attachment in JSON form."""
+
+    filename: str
+    content_base64: str
+
+
+class EmailIngestPayload(BaseModel):
+    """JSON payload for email ingestion (pre-parsed email)."""
+
+    sender: str
+    subject: str
+    body_html: Optional[str] = ""
+    attachments: list[EmailAttachmentPayload] = []
+
+
+def _trigger_extraction(doc_id: int) -> None:
+    """Background task: run OCR + extraction on an email-ingested document."""
+    from lab_manager.api.routes.documents import _run_extraction
+
+    _run_extraction(doc_id)
+
+
+@router.post("/ingest", status_code=201)
+async def ingest_email(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+    """Ingest an email for document extraction.
+
+    Accepts either:
+    - Raw MIME email (Content-Type: message/rfc822 or text/plain)
+    - JSON payload with pre-parsed email fields
+
+    Returns:
+        {documents_created: N, document_ids: [...]}
+    """
+    content_type = request.headers.get("content-type", "").split(";")[0].strip().lower()
+
+    if content_type == "application/json":
+        return await _handle_json_email(request, background_tasks, db)
+    elif content_type in ("message/rfc822", "text/plain"):
+        return await _handle_raw_email(request, background_tasks, db)
+    else:
+        return JSONResponse(
+            status_code=415,
+            content={
+                "detail": (
+                    f"Unsupported Content-Type: {content_type}. "
+                    "Use 'application/json' or 'message/rfc822'."
+                )
+            },
+        )
+
+
+async def _handle_json_email(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session,
+):
+    """Handle JSON-formatted email payload."""
+    from lab_manager.services.email_intake import process_email_json
+
+    try:
+        body = await request.json()
+        payload = EmailIngestPayload(**body)
+    except Exception as e:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": f"Invalid JSON payload: {e}"},
+        )
+
+    if not payload.attachments:
+        return JSONResponse(
+            status_code=422,
+            content={"detail": "No attachments provided"},
+        )
+
+    documents = process_email_json(
+        sender=payload.sender,
+        subject=payload.subject,
+        body_html=payload.body_html or "",
+        attachments_b64=[att.model_dump() for att in payload.attachments],
+        db=db,
+    )
+
+    # Queue background extraction for each document
+    for doc in documents:
+        background_tasks.add_task(_trigger_extraction, doc.id)
+
+    return {
+        "documents_created": len(documents),
+        "document_ids": [doc.id for doc in documents],
+    }
+
+
+async def _handle_raw_email(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    db: Session,
+):
+    """Handle raw MIME email."""
+    from lab_manager.services.email_intake import process_email
+
+    raw_bytes = await request.body()
+    if len(raw_bytes) > _MAX_RAW_EMAIL_BYTES:
+        return JSONResponse(
+            status_code=413,
+            content={
+                "detail": (
+                    f"Email too large ({len(raw_bytes)} bytes). "
+                    f"Maximum: {_MAX_RAW_EMAIL_BYTES} bytes."
+                )
+            },
+        )
+
+    raw_email = raw_bytes.decode("utf-8", errors="replace")
+    documents = process_email(raw_email, db)
+
+    # Queue background extraction for each document
+    for doc in documents:
+        background_tasks.add_task(_trigger_extraction, doc.id)
+
+    return {
+        "documents_created": len(documents),
+        "document_ids": [doc.id for doc in documents],
+    }

--- a/src/lab_manager/services/email_intake.py
+++ b/src/lab_manager/services/email_intake.py
@@ -1,0 +1,344 @@
+"""Email-to-intake agent: parse vendor emails and create Document records.
+
+PI forwards a vendor email -> system auto-extracts order/shipping info ->
+adds to review queue (same as upload flow).
+"""
+
+from __future__ import annotations
+
+import base64
+import email
+import email.policy
+import hashlib
+import logging
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from email.message import EmailMessage
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from lab_manager.config import get_settings
+from lab_manager.models.document import Document, DocumentStatus
+
+logger = logging.getLogger(__name__)
+
+# Attachment types we process
+_IMAGE_CONTENT_TYPES = {"image/png", "image/jpeg", "image/tiff"}
+_PDF_CONTENT_TYPES = {"application/pdf"}
+_SUPPORTED_CONTENT_TYPES = _IMAGE_CONTENT_TYPES | _PDF_CONTENT_TYPES
+
+# Size limits
+_MAX_ATTACHMENT_BYTES = 50 * 1024 * 1024  # 50 MB per attachment
+_MAX_ATTACHMENTS = 20
+
+
+@dataclass
+class Attachment:
+    """Parsed email attachment."""
+
+    filename: str
+    content_type: str
+    data: bytes
+
+
+@dataclass
+class ParsedEmail:
+    """Parsed email metadata and content."""
+
+    sender: str
+    subject: str
+    date: Optional[str]
+    body_text: str
+    body_html: str
+    attachments: list[Attachment] = field(default_factory=list)
+
+
+def parse_email(raw_email: str) -> ParsedEmail:
+    """Parse a raw MIME email string into structured components.
+
+    Args:
+        raw_email: Raw MIME email as string.
+
+    Returns:
+        ParsedEmail with sender, subject, date, body, and attachments.
+    """
+    msg = email.message_from_string(raw_email, policy=email.policy.default)
+
+    sender = str(msg.get("From", ""))
+    subject = str(msg.get("Subject", ""))
+    date_str = str(msg.get("Date", "")) or None
+
+    body_text = ""
+    body_html = ""
+    attachments: list[Attachment] = []
+
+    if msg.is_multipart():
+        for part in msg.walk():
+            content_type = part.get_content_type()
+            disposition = str(part.get("Content-Disposition", ""))
+
+            # Attachment (has filename or explicit attachment disposition)
+            if part.get_filename() or "attachment" in disposition.lower():
+                _extract_attachment(part, attachments)
+                continue
+
+            # Body parts
+            if content_type == "text/plain" and not body_text:
+                payload = part.get_content()
+                body_text = payload if isinstance(payload, str) else str(payload)
+            elif content_type == "text/html" and not body_html:
+                payload = part.get_content()
+                body_html = payload if isinstance(payload, str) else str(payload)
+    else:
+        content_type = msg.get_content_type()
+        payload = msg.get_content()
+        content = payload if isinstance(payload, str) else str(payload)
+        if content_type == "text/html":
+            body_html = content
+        else:
+            body_text = content
+
+    return ParsedEmail(
+        sender=sender,
+        subject=subject,
+        date=date_str if date_str else None,
+        body_text=body_text,
+        body_html=body_html,
+        attachments=attachments,
+    )
+
+
+def _extract_attachment(part: EmailMessage, attachments: list[Attachment]) -> None:
+    """Extract a single attachment from an email part."""
+    if len(attachments) >= _MAX_ATTACHMENTS:
+        logger.warning("Max attachments (%d) reached, skipping", _MAX_ATTACHMENTS)
+        return
+
+    filename = part.get_filename() or "unnamed_attachment"
+    content_type = part.get_content_type()
+    payload = part.get_payload(decode=True)
+
+    if payload is None:
+        logger.warning("Empty payload for attachment %s", filename)
+        return
+
+    if len(payload) > _MAX_ATTACHMENT_BYTES:
+        logger.warning(
+            "Attachment %s too large (%d bytes), skipping",
+            filename,
+            len(payload),
+        )
+        return
+
+    attachments.append(
+        Attachment(filename=filename, content_type=content_type, data=payload)
+    )
+
+
+def extract_attachments(parsed: ParsedEmail) -> list[Attachment]:
+    """Filter attachments to only supported types (PDF, PNG, JPG, TIFF).
+
+    Args:
+        parsed: ParsedEmail from parse_email().
+
+    Returns:
+        List of Attachment objects with supported content types.
+    """
+    supported = []
+    for att in parsed.attachments:
+        if att.content_type in _SUPPORTED_CONTENT_TYPES:
+            supported.append(att)
+        else:
+            logger.info(
+                "Skipping unsupported attachment type %s for %s",
+                att.content_type,
+                att.filename,
+            )
+    return supported
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize attachment filename for safe storage."""
+    safe = name.replace("/", "_").replace("\\", "_").replace("\x00", "")
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "_", safe)
+    if not safe or safe.startswith("."):
+        safe = "attachment" + safe
+    return safe
+
+
+def _save_attachment(att: Attachment, upload_dir: Path) -> tuple[Path, str]:
+    """Save attachment bytes to upload directory with dedup.
+
+    Returns:
+        Tuple of (file_path, saved_filename).
+    """
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    content_hash = hashlib.sha256(att.data).hexdigest()[:16]
+    now = datetime.now()
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    usec = f"{now.microsecond:06d}"
+
+    safe_name = _sanitize_filename(att.filename)
+    stem = Path(safe_name).stem
+    suffix = Path(safe_name).suffix
+    saved_name = f"{timestamp}_{usec}_email_{stem}_{content_hash}{suffix}"
+
+    dest = upload_dir / saved_name
+    dest.write_bytes(att.data)
+    return dest, saved_name
+
+
+def process_email(raw_email: str, db: Session) -> list[Document]:
+    """Full email-to-intake pipeline.
+
+    1. Parse email (sender, subject, date, body)
+    2. Extract supported attachments (PDFs, images)
+    3. For each attachment: create Document record with source="email"
+    4. Queue for OCR/extraction (same as upload flow)
+
+    Args:
+        raw_email: Raw MIME email string.
+        db: SQLAlchemy session.
+
+    Returns:
+        List of Document records created.
+    """
+    parsed = parse_email(raw_email)
+    attachments = extract_attachments(parsed)
+
+    if not attachments:
+        logger.info(
+            "No supported attachments in email from=%s subject=%s",
+            parsed.sender,
+            parsed.subject,
+        )
+        return []
+
+    settings = get_settings()
+    upload_dir = Path(settings.upload_dir)
+    documents: list[Document] = []
+
+    email_metadata = {
+        "source": "email",
+        "email_from": parsed.sender,
+        "email_subject": parsed.subject,
+        "email_date": parsed.date,
+    }
+
+    for att in attachments:
+        dest, saved_name = _save_attachment(att, upload_dir)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name=saved_name,
+            status=DocumentStatus.processing,
+            review_notes=(
+                f"Email intake: from={parsed.sender}, subject={parsed.subject}"
+            ),
+            extracted_data=email_metadata,
+        )
+        db.add(doc)
+        db.flush()
+
+        logger.info(
+            "Created document %d from email attachment %s (from=%s)",
+            doc.id,
+            att.filename,
+            parsed.sender,
+        )
+        documents.append(doc)
+
+    db.commit()
+    for doc in documents:
+        db.refresh(doc)
+
+    return documents
+
+
+def process_email_json(
+    sender: str,
+    subject: str,
+    body_html: str,
+    attachments_b64: list[dict],
+    db: Session,
+) -> list[Document]:
+    """Process email from JSON payload (pre-parsed).
+
+    Args:
+        sender: Email sender address.
+        subject: Email subject line.
+        body_html: HTML body content.
+        attachments_b64: List of {"filename": str, "content_base64": str}.
+        db: SQLAlchemy session.
+
+    Returns:
+        List of Document records created.
+    """
+    settings = get_settings()
+    upload_dir = Path(settings.upload_dir)
+    documents: list[Document] = []
+
+    email_metadata = {
+        "source": "email",
+        "email_from": sender,
+        "email_subject": subject,
+    }
+
+    for att_data in attachments_b64:
+        filename = att_data.get("filename", "unnamed.bin")
+        content_b64 = att_data.get("content_base64", "")
+
+        try:
+            data = base64.b64decode(content_b64)
+        except Exception:
+            logger.warning("Failed to decode base64 for attachment %s", filename)
+            continue
+
+        if len(data) > _MAX_ATTACHMENT_BYTES:
+            logger.warning("Attachment %s too large, skipping", filename)
+            continue
+
+        # Infer content type from extension
+        ext = Path(filename).suffix.lower()
+        content_type_map = {
+            ".pdf": "application/pdf",
+            ".png": "image/png",
+            ".jpg": "image/jpeg",
+            ".jpeg": "image/jpeg",
+            ".tiff": "image/tiff",
+            ".tif": "image/tiff",
+        }
+        content_type = content_type_map.get(ext)
+        if not content_type:
+            logger.info("Skipping unsupported file type: %s", filename)
+            continue
+
+        att = Attachment(filename=filename, content_type=content_type, data=data)
+        dest, saved_name = _save_attachment(att, upload_dir)
+
+        doc = Document(
+            file_path=str(dest),
+            file_name=saved_name,
+            status=DocumentStatus.processing,
+            review_notes=f"Email intake: from={sender}, subject={subject}",
+            extracted_data=email_metadata,
+        )
+        db.add(doc)
+        db.flush()
+
+        logger.info(
+            "Created document %d from JSON email attachment %s",
+            doc.id,
+            filename,
+        )
+        documents.append(doc)
+
+    if documents:
+        db.commit()
+        for doc in documents:
+            db.refresh(doc)
+
+    return documents

--- a/src/lab_manager/services/email_poller.py
+++ b/src/lab_manager/services/email_poller.py
@@ -1,0 +1,140 @@
+"""IMAP email poller: periodically checks a mailbox for new vendor emails.
+
+Configuration via environment variables:
+  EMAIL_IMAP_HOST: IMAP server hostname
+  EMAIL_IMAP_USER: IMAP username (email address)
+  EMAIL_IMAP_PASSWORD: IMAP password
+  EMAIL_FOLDER: Mailbox folder to monitor (default: INBOX)
+  EMAIL_POLL_INTERVAL: Polling interval in seconds (default: 300 = 5 min)
+"""
+
+from __future__ import annotations
+
+import imaplib
+import logging
+import os
+import time
+
+logger = logging.getLogger(__name__)
+
+# Default polling interval: 5 minutes
+DEFAULT_POLL_INTERVAL = 300
+
+
+def _get_imap_config() -> dict:
+    """Read IMAP configuration from environment."""
+    host = os.environ.get("EMAIL_IMAP_HOST", "")
+    user = os.environ.get("EMAIL_IMAP_USER", "")
+    password = os.environ.get("EMAIL_IMAP_PASSWORD", "")
+    folder = os.environ.get("EMAIL_FOLDER", "INBOX")
+    interval = int(os.environ.get("EMAIL_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL)))
+    return {
+        "host": host,
+        "user": user,
+        "password": password,
+        "folder": folder,
+        "interval": interval,
+    }
+
+
+def _connect_imap(config: dict) -> imaplib.IMAP4_SSL:
+    """Connect and authenticate to IMAP server."""
+    conn = imaplib.IMAP4_SSL(config["host"])
+    conn.login(config["user"], config["password"])
+    return conn
+
+
+def _fetch_unseen_emails(conn: imaplib.IMAP4_SSL, folder: str) -> list[str]:
+    """Fetch unseen email bodies from the specified folder.
+
+    Returns list of raw email strings. Marks fetched emails as Seen.
+    """
+    conn.select(folder)
+    _, msg_nums = conn.search(None, "UNSEEN")
+
+    raw_emails: list[str] = []
+    for num in msg_nums[0].split():
+        if not num:
+            continue
+        _, data = conn.fetch(num, "(RFC822)")
+        if data and data[0] and isinstance(data[0], tuple):
+            raw_bytes = data[0][1]
+            if isinstance(raw_bytes, bytes):
+                raw_emails.append(raw_bytes.decode("utf-8", errors="replace"))
+        # Mark as seen (IMAP fetch with RFC822 already sets \Seen flag)
+
+    return raw_emails
+
+
+def poll_once() -> int:
+    """Poll mailbox once for new emails and process them.
+
+    Returns:
+        Number of documents created.
+    """
+    from lab_manager.database import get_db_session
+    from lab_manager.services.email_intake import process_email
+
+    config = _get_imap_config()
+    if not config["host"] or not config["user"]:
+        logger.debug("Email polling not configured (missing EMAIL_IMAP_HOST/USER)")
+        return 0
+
+    total_docs = 0
+    try:
+        conn = _connect_imap(config)
+        try:
+            raw_emails = _fetch_unseen_emails(conn, config["folder"])
+            logger.info(
+                "Found %d unseen emails in %s", len(raw_emails), config["folder"]
+            )
+
+            for raw_email in raw_emails:
+                try:
+                    with get_db_session() as db:
+                        docs = process_email(raw_email, db)
+                        total_docs += len(docs)
+                        if docs:
+                            logger.info("Processed email -> %d document(s)", len(docs))
+                except Exception:
+                    logger.exception("Failed to process email")
+        finally:
+            try:
+                conn.logout()
+            except Exception:
+                pass
+    except Exception:
+        logger.exception("IMAP connection failed")
+
+    return total_docs
+
+
+def run_poller() -> None:
+    """Run the email poller in a loop. Blocks forever.
+
+    Intended to be started in a background thread or separate process.
+    """
+    config = _get_imap_config()
+    if not config["host"] or not config["user"]:
+        logger.warning(
+            "Email poller not starting: EMAIL_IMAP_HOST and EMAIL_IMAP_USER required"
+        )
+        return
+
+    interval = config["interval"]
+    logger.info(
+        "Email poller starting: host=%s, user=%s, folder=%s, interval=%ds",
+        config["host"],
+        config["user"],
+        config["folder"],
+        interval,
+    )
+
+    while True:
+        try:
+            count = poll_once()
+            if count:
+                logger.info("Poll cycle: created %d document(s)", count)
+        except Exception:
+            logger.exception("Error in poll cycle")
+        time.sleep(interval)

--- a/tests/test_email_intake.py
+++ b/tests/test_email_intake.py
@@ -1,0 +1,537 @@
+"""Tests for the email-to-intake pipeline.
+
+Covers: parse_email, extract_attachments, process_email, JSON API, raw MIME API.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import struct
+import zlib
+from email.mime.application import MIMEApplication
+from email.mime.image import MIMEImage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from unittest.mock import patch
+
+import pytest
+
+from lab_manager.config import get_settings
+from lab_manager.models.document import DocumentStatus
+from lab_manager.services.email_intake import (
+    Attachment,
+    ParsedEmail,
+    extract_attachments,
+    parse_email,
+    process_email,
+    process_email_json,
+)
+
+
+@pytest.fixture(autouse=True)
+def _email_test_settings(monkeypatch):
+    monkeypatch.setenv("AUTH_ENABLED", "false")
+    monkeypatch.setenv("ADMIN_SECRET_KEY", "test-secret-key-not-for-production")
+    monkeypatch.setenv("ADMIN_PASSWORD", "test-admin-password-not-for-production")
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _make_png() -> bytes:
+    """Minimal valid 1x1 PNG."""
+
+    def _chunk(ct: bytes, data: bytes) -> bytes:
+        c = ct + data
+        crc = struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + c + crc
+
+    sig = b"\x89PNG\r\n\x1a\n"
+    ihdr = _chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 2, 0, 0, 0))
+    raw = zlib.compress(b"\x00\xff\xff\xff")
+    idat = _chunk(b"IDAT", raw)
+    iend = _chunk(b"IEND", b"")
+    return sig + ihdr + idat + iend
+
+
+def _make_pdf() -> bytes:
+    """Minimal valid PDF."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/MediaBox[0 0 612 792]/Parent 2 0 R>>endobj\n"
+        b"xref\n0 4\n"
+        b"0000000000 65535 f \n"
+        b"0000000009 00000 n \n"
+        b"0000000058 00000 n \n"
+        b"0000000115 00000 n \n"
+        b"trailer<</Size 4/Root 1 0 R>>\n"
+        b"startxref\n183\n%%EOF\n"
+    )
+
+
+def _build_email_with_pdf(
+    sender: str = "vendor@sigma.com",
+    subject: str = "Your Order Shipped - PO-12345",
+    body: str = "Your order has shipped. Please find packing list attached.",
+    filename: str = "packing_list.pdf",
+    attachment_data: bytes | None = None,
+) -> str:
+    """Build a MIME email with a PDF attachment."""
+    msg = MIMEMultipart()
+    msg["From"] = sender
+    msg["To"] = "pi@lab.edu"
+    msg["Subject"] = subject
+    msg["Date"] = "Mon, 24 Mar 2026 10:00:00 -0400"
+
+    msg.attach(MIMEText(body, "plain"))
+
+    data = attachment_data or _make_pdf()
+    att = MIMEApplication(data, _subtype="pdf")
+    att.add_header("Content-Disposition", "attachment", filename=filename)
+    msg.attach(att)
+
+    return msg.as_string()
+
+
+def _build_email_with_image(
+    sender: str = "vendor@thermo.com",
+    subject: str = "Shipment Confirmation",
+    filename: str = "receipt.png",
+) -> str:
+    """Build a MIME email with a PNG image attachment."""
+    msg = MIMEMultipart()
+    msg["From"] = sender
+    msg["To"] = "pi@lab.edu"
+    msg["Subject"] = subject
+
+    msg.attach(MIMEText("See attached receipt image.", "plain"))
+
+    png_data = _make_png()
+    att = MIMEImage(png_data, _subtype="png")
+    att.add_header("Content-Disposition", "attachment", filename=filename)
+    msg.attach(att)
+
+    return msg.as_string()
+
+
+def _build_email_no_attachments() -> str:
+    """Build a MIME email with no attachments."""
+    msg = MIMEMultipart()
+    msg["From"] = "person@example.com"
+    msg["To"] = "pi@lab.edu"
+    msg["Subject"] = "Just a text email"
+    msg.attach(MIMEText("No attachments here.", "plain"))
+    return msg.as_string()
+
+
+class TestParseEmail:
+    """Test parse_email() with various MIME structures."""
+
+    def test_parse_simple_email_with_pdf(self):
+        """Parse email with PDF attachment extracts sender, subject, body, and attachment."""
+        raw = _build_email_with_pdf()
+        parsed = parse_email(raw)
+
+        assert parsed.sender == "vendor@sigma.com"
+        assert parsed.subject == "Your Order Shipped - PO-12345"
+        assert "order has shipped" in parsed.body_text
+        assert parsed.date is not None
+        assert len(parsed.attachments) == 1
+        assert parsed.attachments[0].filename == "packing_list.pdf"
+        assert parsed.attachments[0].content_type == "application/pdf"
+
+    def test_parse_email_with_image(self):
+        """Parse email with PNG image attachment."""
+        raw = _build_email_with_image()
+        parsed = parse_email(raw)
+
+        assert parsed.sender == "vendor@thermo.com"
+        assert parsed.subject == "Shipment Confirmation"
+        assert len(parsed.attachments) == 1
+        assert parsed.attachments[0].filename == "receipt.png"
+        assert parsed.attachments[0].content_type == "image/png"
+        assert parsed.attachments[0].data == _make_png()
+
+    def test_parse_email_no_attachments(self):
+        """Parse plain text email with no attachments."""
+        raw = _build_email_no_attachments()
+        parsed = parse_email(raw)
+
+        assert parsed.sender == "person@example.com"
+        assert parsed.subject == "Just a text email"
+        assert "No attachments" in parsed.body_text
+        assert len(parsed.attachments) == 0
+
+    def test_parse_email_html_body(self):
+        """Parse email with HTML body content."""
+        msg = MIMEMultipart("alternative")
+        msg["From"] = "vendor@example.com"
+        msg["Subject"] = "HTML Email"
+        msg.attach(MIMEText("Plain text version", "plain"))
+        msg.attach(MIMEText("<h1>HTML version</h1>", "html"))
+
+        parsed = parse_email(msg.as_string())
+        assert parsed.body_text == "Plain text version"
+        assert "<h1>HTML version</h1>" in parsed.body_html
+
+
+class TestExtractAttachments:
+    """Test extract_attachments() filtering."""
+
+    def test_filters_supported_types(self):
+        """Only PDF and image attachments pass the filter."""
+        parsed = ParsedEmail(
+            sender="test@example.com",
+            subject="Test",
+            date=None,
+            body_text="",
+            body_html="",
+            attachments=[
+                Attachment(
+                    filename="doc.pdf", content_type="application/pdf", data=b"pdf"
+                ),
+                Attachment(filename="photo.png", content_type="image/png", data=b"png"),
+                Attachment(filename="data.csv", content_type="text/csv", data=b"csv"),
+                Attachment(
+                    filename="archive.zip",
+                    content_type="application/zip",
+                    data=b"zip",
+                ),
+            ],
+        )
+
+        supported = extract_attachments(parsed)
+        assert len(supported) == 2
+        filenames = {a.filename for a in supported}
+        assert filenames == {"doc.pdf", "photo.png"}
+
+    def test_empty_attachments(self):
+        """No attachments returns empty list."""
+        parsed = ParsedEmail(
+            sender="test@example.com",
+            subject="Test",
+            date=None,
+            body_text="",
+            body_html="",
+            attachments=[],
+        )
+
+        assert extract_attachments(parsed) == []
+
+
+class TestProcessEmail:
+    """Test process_email() end-to-end pipeline."""
+
+    def test_process_email_creates_documents(self, db_session, tmp_path):
+        """Process email with PDF attachment creates Document record."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        raw = _build_email_with_pdf()
+        docs = process_email(raw, db_session)
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc.id is not None
+        assert doc.status == DocumentStatus.processing
+        assert "Email intake" in doc.review_notes
+        assert "vendor@sigma.com" in doc.review_notes
+        assert doc.extracted_data["source"] == "email"
+        assert doc.extracted_data["email_from"] == "vendor@sigma.com"
+        assert doc.extracted_data["email_subject"] == "Your Order Shipped - PO-12345"
+
+        # File was saved to disk
+        from pathlib import Path
+
+        assert Path(doc.file_path).exists()
+
+        get_settings.cache_clear()
+
+    def test_process_email_no_supported_attachments(self, db_session, tmp_path):
+        """Email with no supported attachments creates zero documents."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        raw = _build_email_no_attachments()
+        docs = process_email(raw, db_session)
+
+        assert len(docs) == 0
+
+        get_settings.cache_clear()
+
+    def test_process_email_multiple_attachments(self, db_session, tmp_path):
+        """Email with multiple supported attachments creates one Document per attachment."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        # Build email with PDF + image
+        msg = MIMEMultipart()
+        msg["From"] = "vendor@bio-rad.com"
+        msg["To"] = "pi@lab.edu"
+        msg["Subject"] = "Order Documents"
+        msg.attach(MIMEText("Multiple documents attached.", "plain"))
+
+        pdf_att = MIMEApplication(_make_pdf(), _subtype="pdf")
+        pdf_att.add_header("Content-Disposition", "attachment", filename="invoice.pdf")
+        msg.attach(pdf_att)
+
+        img_att = MIMEImage(_make_png(), _subtype="png")
+        img_att.add_header("Content-Disposition", "attachment", filename="label.png")
+        msg.attach(img_att)
+
+        raw = msg.as_string()
+        docs = process_email(raw, db_session)
+
+        assert len(docs) == 2
+        filenames = {d.file_name for d in docs}
+        assert any("invoice" in f for f in filenames)
+        assert any("label" in f for f in filenames)
+
+        get_settings.cache_clear()
+
+
+class TestProcessEmailJson:
+    """Test process_email_json() with base64 attachments."""
+
+    def test_json_with_pdf(self, db_session, tmp_path):
+        """JSON email with base64 PDF creates Document."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        pdf_data = _make_pdf()
+        pdf_b64 = base64.b64encode(pdf_data).decode()
+
+        docs = process_email_json(
+            sender="vendor@fisher.com",
+            subject="Invoice #INV-2026-001",
+            body_html="<p>Invoice attached</p>",
+            attachments_b64=[
+                {"filename": "invoice.pdf", "content_base64": pdf_b64},
+            ],
+            db=db_session,
+        )
+
+        assert len(docs) == 1
+        doc = docs[0]
+        assert doc.status == DocumentStatus.processing
+        assert "vendor@fisher.com" in doc.review_notes
+        assert doc.extracted_data["source"] == "email"
+
+        get_settings.cache_clear()
+
+    def test_json_unsupported_extension_skipped(self, db_session, tmp_path):
+        """JSON email with unsupported file extension creates no documents."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        docs = process_email_json(
+            sender="vendor@example.com",
+            subject="Spreadsheet",
+            body_html="",
+            attachments_b64=[
+                {
+                    "filename": "data.xlsx",
+                    "content_base64": base64.b64encode(b"xlsx data").decode(),
+                },
+            ],
+            db=db_session,
+        )
+
+        assert len(docs) == 0
+
+        get_settings.cache_clear()
+
+    def test_json_invalid_base64_skipped(self, db_session, tmp_path):
+        """Invalid base64 content is skipped without crashing."""
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        get_settings.cache_clear()
+
+        docs = process_email_json(
+            sender="vendor@example.com",
+            subject="Bad attachment",
+            body_html="",
+            attachments_b64=[
+                {"filename": "doc.pdf", "content_base64": "not-valid-base64!!!"},
+            ],
+            db=db_session,
+        )
+
+        assert len(docs) == 0
+
+        get_settings.cache_clear()
+
+
+class TestEmailIngestAPI:
+    """Test POST /api/v1/email/ingest endpoint."""
+
+    @pytest.fixture
+    def upload_dir(self, tmp_path):
+        d = tmp_path / "uploads"
+        d.mkdir()
+        os.environ["UPLOAD_DIR"] = str(d)
+        get_settings.cache_clear()
+        yield d
+        get_settings.cache_clear()
+
+    @pytest.fixture
+    def email_client(self, upload_dir, db_session):
+        os.environ["AUTH_ENABLED"] = "false"
+        get_settings.cache_clear()
+
+        from lab_manager.api.app import create_app
+        from lab_manager.api.deps import get_db
+
+        app = create_app()
+
+        def override_get_db():
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        from fastapi.testclient import TestClient
+
+        with TestClient(app) as c:
+            yield c
+
+    @patch("lab_manager.api.routes.email_ingest._trigger_extraction")
+    def test_json_ingest_creates_documents(self, mock_extract, email_client):
+        """JSON email ingest creates documents and returns IDs."""
+        pdf_b64 = base64.b64encode(_make_pdf()).decode()
+        resp = email_client.post(
+            "/api/v1/email/ingest",
+            json={
+                "sender": "vendor@sigma.com",
+                "subject": "PO-12345 Shipped",
+                "body_html": "<p>Shipped</p>",
+                "attachments": [
+                    {"filename": "packing_list.pdf", "content_base64": pdf_b64},
+                ],
+            },
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["documents_created"] == 1
+        assert len(data["document_ids"]) == 1
+        mock_extract.assert_called_once()
+
+    @patch("lab_manager.api.routes.email_ingest._trigger_extraction")
+    def test_raw_mime_ingest(self, mock_extract, email_client):
+        """Raw MIME email ingest creates documents."""
+        raw = _build_email_with_pdf()
+        resp = email_client.post(
+            "/api/v1/email/ingest",
+            content=raw.encode("utf-8"),
+            headers={"Content-Type": "message/rfc822"},
+        )
+
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["documents_created"] == 1
+        assert len(data["document_ids"]) == 1
+
+    def test_unsupported_content_type(self, email_client):
+        """Unsupported Content-Type returns 415."""
+        resp = email_client.post(
+            "/api/v1/email/ingest",
+            content=b"<xml>not email</xml>",
+            headers={"Content-Type": "application/xml"},
+        )
+
+        assert resp.status_code == 415
+
+    def test_json_no_attachments_returns_422(self, email_client):
+        """JSON email with no attachments returns 422."""
+        resp = email_client.post(
+            "/api/v1/email/ingest",
+            json={
+                "sender": "vendor@example.com",
+                "subject": "No docs",
+                "attachments": [],
+            },
+        )
+
+        assert resp.status_code == 422
+
+
+class TestEmailPoller:
+    """Test email_poller module."""
+
+    def test_poll_once_not_configured(self):
+        """poll_once returns 0 when IMAP not configured."""
+        os.environ.pop("EMAIL_IMAP_HOST", None)
+        os.environ.pop("EMAIL_IMAP_USER", None)
+
+        from lab_manager.services.email_poller import poll_once
+
+        result = poll_once()
+        assert result == 0
+
+    def test_poll_once_with_mock_imap(self, db_session, tmp_path):
+        """poll_once processes emails from mocked IMAP connection."""
+        from contextlib import contextmanager
+
+        upload_dir = tmp_path / "uploads"
+        upload_dir.mkdir()
+        os.environ["UPLOAD_DIR"] = str(upload_dir)
+        os.environ["EMAIL_IMAP_HOST"] = "imap.example.com"
+        os.environ["EMAIL_IMAP_USER"] = "lab@example.com"
+        os.environ["EMAIL_IMAP_PASSWORD"] = "secret"
+        get_settings.cache_clear()
+
+        raw_email_str = _build_email_with_pdf()
+
+        mock_conn = type(
+            "MockIMAP",
+            (),
+            {
+                "login": lambda self, u, p: None,
+                "select": lambda self, f: ("OK", [b"1"]),
+                "search": lambda self, charset, criteria: ("OK", [b"1"]),
+                "fetch": lambda self, num, parts: (
+                    "OK",
+                    [(b"1 (RFC822 {1234})", raw_email_str.encode("utf-8"))],
+                ),
+                "logout": lambda self: None,
+            },
+        )()
+
+        @contextmanager
+        def fake_db_session():
+            yield db_session
+
+        with (
+            patch(
+                "lab_manager.services.email_poller._connect_imap",
+                return_value=mock_conn,
+            ),
+            patch(
+                "lab_manager.database.get_db_session",
+                side_effect=fake_db_session,
+            ),
+        ):
+            from lab_manager.services.email_poller import poll_once
+
+            result = poll_once()
+
+        assert result == 1
+
+        # Clean up env
+        os.environ.pop("EMAIL_IMAP_HOST", None)
+        os.environ.pop("EMAIL_IMAP_USER", None)
+        os.environ.pop("EMAIL_IMAP_PASSWORD", None)
+        get_settings.cache_clear()


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/email/ingest` endpoint accepting raw MIME (`message/rfc822`) or JSON payloads with base64 attachments
- New `email_intake` service: parse MIME emails, extract PDF/PNG/JPG/TIFF attachments, create Document records with `source=email` metadata, queue for OCR/extraction
- New `email_poller` service: optional IMAP polling (configurable via `EMAIL_IMAP_HOST`, `EMAIL_IMAP_USER`, `EMAIL_IMAP_PASSWORD`, `EMAIL_FOLDER` env vars) that checks mailbox every 5 minutes for new vendor emails
- 18 tests covering parse, extract, process, JSON API, raw MIME API, and poller

## Test plan
- [x] `pytest tests/test_email_intake.py` -- 18/18 passing
- [x] `ruff check src/` -- all checks passed
- [x] Existing tests unaffected (verified with test_config, test_exceptions)
- [ ] CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)