### PR TITLE
feat(api): batch inventory ops, vendor merge, auto-expiry

### DIFF
--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -107,6 +107,33 @@ class OpenBody(BaseModel):
     opened_by: str = Field(max_length=200)
 
 
+class BatchConsumeItem(BaseModel):
+    item_id: int
+    quantity: Decimal = Field(gt=0)
+    purpose: Optional[str] = Field(default=None, max_length=500)
+
+
+class BatchConsumeBody(BaseModel):
+    items: list[BatchConsumeItem] = Field(min_length=1, max_length=100)
+    consumed_by: str = Field(max_length=200)
+
+
+class BatchDisposeItem(BaseModel):
+    item_id: int
+    reason: str = Field(max_length=500)
+
+
+class BatchDisposeBody(BaseModel):
+    items: list[BatchDisposeItem] = Field(min_length=1, max_length=100)
+    disposed_by: str = Field(max_length=200)
+
+
+class BatchResult(BaseModel):
+    succeeded: int = 0
+    failed: int = 0
+    errors: list[str] = []
+
+
 # ---------------------------------------------------------------------------
 # Fixed-path routes MUST come before /{item_id} parameter routes
 # ---------------------------------------------------------------------------
@@ -152,6 +179,44 @@ def create_inventory_item(body: InventoryItemCreate, db: Session = Depends(get_d
     db.flush()
     db.refresh(item)
     return item
+
+
+@router.post("/batch/consume")
+def batch_consume(body: BatchConsumeBody, db: Session = Depends(get_db)):
+    """Consume multiple inventory items in one request.
+
+    Scientists often need to log consumption for several items at once
+    (e.g., after completing an experiment).  Each item is processed
+    independently -- failures don't roll back successful items.
+    """
+    result = BatchResult()
+    for item in body.items:
+        try:
+            inv_svc.consume(
+                item.item_id, item.quantity, body.consumed_by, item.purpose, db
+            )
+            result.succeeded += 1
+        except Exception as e:
+            result.failed += 1
+            result.errors.append(f"Item {item.item_id}: {e}")
+    return result
+
+
+@router.post("/batch/dispose")
+def batch_dispose(body: BatchDisposeBody, db: Session = Depends(get_db)):
+    """Dispose multiple inventory items in one request.
+
+    Useful for bulk cleanup of expired or contaminated items.
+    """
+    result = BatchResult()
+    for item in body.items:
+        try:
+            inv_svc.dispose(item.item_id, item.reason, body.disposed_by, db)
+            result.succeeded += 1
+        except Exception as e:
+            result.failed += 1
+            result.errors.append(f"Item {item.item_id}: {e}")
+    return result
 
 
 @router.get("/low-stock")

--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -117,6 +117,66 @@ def delete_vendor(vendor_id: int, db: Session = Depends(get_db)):
     return None
 
 
+class VendorMergeBody(BaseModel):
+    """Merge one vendor into another.  All references move to target."""
+
+    source_vendor_id: int
+    target_vendor_id: int
+    add_as_alias: bool = True
+
+
+@router.post("/merge")
+def merge_vendors(body: VendorMergeBody, db: Session = Depends(get_db)):
+    """Merge source vendor into target.  Moves all products and orders.
+
+    Scientists often end up with duplicate vendors from OCR variations
+    ("Sigma-Aldrich" vs "Sigma Aldrich").  This merges them into one.
+    """
+    if body.source_vendor_id == body.target_vendor_id:
+        raise ConflictError("Cannot merge a vendor with itself")
+
+    source = get_or_404(db, Vendor, body.source_vendor_id, "Source vendor")
+    target = get_or_404(db, Vendor, body.target_vendor_id, "Target vendor")
+
+    # Move all products from source to target
+    products_moved = 0
+    source_products = db.scalars(
+        select(Product).where(Product.vendor_id == source.id)
+    ).all()
+    for p in source_products:
+        p.vendor_id = target.id
+        products_moved += 1
+
+    # Move all orders from source to target
+    orders_moved = 0
+    source_orders = db.scalars(select(Order).where(Order.vendor_id == source.id)).all()
+    for o in source_orders:
+        o.vendor_id = target.id
+        orders_moved += 1
+
+    # Add source name as alias on target
+    if body.add_as_alias:
+        aliases = list(target.aliases or [])
+        if source.name not in aliases and source.name != target.name:
+            aliases.append(source.name)
+        for alias in source.aliases or []:
+            if alias not in aliases and alias != target.name:
+                aliases.append(alias)
+        target.aliases = aliases
+
+    db.delete(source)
+    db.flush()
+    db.refresh(target)
+
+    return {
+        "merged_into": target.id,
+        "target_name": target.name,
+        "products_moved": products_moved,
+        "orders_moved": orders_moved,
+        "aliases": target.aliases,
+    }
+
+
 @router.get("/{vendor_id}/products")
 def list_vendor_products(
     vendor_id: int,

--- a/src/lab_manager/services/inventory.py
+++ b/src/lab_manager/services/inventory.py
@@ -103,13 +103,22 @@ def receive_items(
                 f"Order item {order_item_id} belongs to order {order_item.order_id}, not {order_id}"
             )
 
+        product_id = order_item.product_id if order_item else ri.get("product_id")
+
+        # Auto-calculate expiry from product.shelf_life_days when not provided
+        expiry = ri.get("expiry_date")
+        if not expiry and product_id:
+            product = db.get(Product, product_id)
+            if product and product.shelf_life_days:
+                expiry = today + timedelta(days=product.shelf_life_days)
+
         inv_kwargs = dict(
-            product_id=order_item.product_id if order_item else ri.get("product_id"),
+            product_id=product_id,
             lot_number=ri.get("lot_number")
             or (order_item.lot_number if order_item else None),
             quantity_on_hand=ri.get("quantity", 1),
             unit=ri.get("unit") or (order_item.unit if order_item else None),
-            expiry_date=ri.get("expiry_date"),
+            expiry_date=expiry,
             status=InventoryStatus.available,
             received_by=received_by,
             order_item_id=order_item_id,


### PR DESCRIPTION
## Summary

Three closely related backend API improvements that reduce manual repetitive work for scientists managing lab inventory:

- **Batch consume/dispose** (`POST /inventory/batch/consume`, `POST /inventory/batch/dispose`): Scientists can process multiple items in one request instead of N individual calls. Each item is processed independently — partial failures don't roll back successes.

- **Vendor merge** (`POST /vendors/merge`): Deduplicates vendors created by OCR variations (e.g. "Sigma-Aldrich" vs "Sigma Aldrich"). Moves all products and orders to the target vendor, carries aliases, deletes the source.

- **Auto-expiry calculation**: When receiving inventory items, if no `expiry_date` is provided but the product has `shelf_life_days` configured, the system auto-calculates `expiry_date = received_date + shelf_life_days`. Prevents missing expiry alerts.

All three changes are backend-only (no frontend changes) and share the theme of reducing manual data entry for scientists.

## Test plan

- [ ] `POST /inventory/batch/consume` with 3 items — verify all consumed, quantities updated
- [ ] `POST /inventory/batch/consume` with 1 invalid item — verify partial success (2 succeed, 1 error)
- [ ] `POST /vendors/merge` — verify products/orders moved, aliases carried, source deleted
- [ ] `POST /vendors/merge` with same source=target — verify 409 error
- [ ] `POST /orders/{id}/receive` with product having `shelf_life_days=90` and no `expiry_date` — verify auto-calculated
- [ ] `ruff check` and `ruff format --check` pass on changed files

https://claude.ai/code/session_0198cc91V7TZZWrHE6Sra4KM