### PR TITLE
feat(web): enhance React frontend for scientist UX

### DIFF
--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -146,6 +146,12 @@ export interface AskEvidenceRow {
   [key: string]: unknown
 }
 
+export interface SuggestedAction {
+  label: string
+  action_type: 'navigate' | 'ask' | 'api_call' | string
+  target: string
+}
+
 export interface AskResponse {
   question: string
   answer: string
@@ -153,6 +159,20 @@ export interface AskResponse {
   raw_results: AskEvidenceRow[]
   row_count?: number
   source: 'sql' | 'search' | string
+  suggested_actions?: SuggestedAction[]
+}
+
+export interface ImportResult {
+  created: number
+  skipped: number
+  errors: string[]
+  total_rows: number
+}
+
+export interface BatchResult {
+  succeeded: number
+  failed: number
+  errors: string[]
 }
 
 async function apiFetch<T>(url: string, opts?: RequestInit): Promise<T> {
@@ -357,5 +377,42 @@ export const ask = {
     apiFetch<AskResponse>('/ask', {
       method: 'POST',
       body: JSON.stringify({ question }),
+    }),
+}
+
+// Bulk import
+export const bulkImport = {
+  products: (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return apiFetch<ImportResult>('/import/products', { method: 'POST', body: form })
+  },
+  vendors: (file: File) => {
+    const form = new FormData()
+    form.append('file', file)
+    return apiFetch<ImportResult>('/import/vendors', { method: 'POST', body: form })
+  },
+}
+
+// Vendor merge
+export const vendorOps = {
+  merge: (sourceId: number, targetId: number, addAsAlias = true) =>
+    apiFetch<{ merged_into: number; target_name: string; products_moved: number; orders_moved: number }>('/vendors/merge', {
+      method: 'POST',
+      body: JSON.stringify({ source_vendor_id: sourceId, target_vendor_id: targetId, add_as_alias: addAsAlias }),
+    }),
+}
+
+// Batch inventory operations
+export const batchInventory = {
+  consume: (items: Array<{ item_id: number; quantity: number; purpose?: string }>, consumedBy: string) =>
+    apiFetch<BatchResult>('/inventory/batch/consume', {
+      method: 'POST',
+      body: JSON.stringify({ items, consumed_by: consumedBy }),
+    }),
+  dispose: (items: Array<{ item_id: number; reason: string }>, disposedBy: string) =>
+    apiFetch<BatchResult>('/inventory/batch/dispose', {
+      method: 'POST',
+      body: JSON.stringify({ items, disposed_by: disposedBy }),
     }),
 }

--- a/web/src/pages/AskPage.tsx
+++ b/web/src/pages/AskPage.tsx
@@ -20,7 +20,7 @@ import {
   Check,
 } from 'lucide-react'
 import { ask } from '@/lib/api'
-import type { AskEvidenceRow, AskResponse } from '@/lib/api'
+import type { AskEvidenceRow, AskResponse, SuggestedAction } from '@/lib/api'
 
 /* ────────────────────────────────────────────────────────────────────────── */
 /*  Types                                                                    */
@@ -37,6 +37,7 @@ interface ChatMessage {
   evidence?: AskEvidenceRow[]
   source?: string
   rowCount?: number
+  suggestedActions?: SuggestedAction[]
   timestamp: string
 }
 
@@ -57,6 +58,7 @@ type AskTurn = {
   readonly sql?: string | null
   readonly evidence?: AskEvidenceRow[]
   readonly rowCount?: number
+  readonly suggestedActions?: SuggestedAction[]
   readonly error?: string
 }
 
@@ -734,6 +736,7 @@ export function AskPage({ onError }: Readonly<AskPageProps>) {
           evidence: turn.evidence,
           source: turn.source,
           rowCount: turn.rowCount,
+          suggestedActions: turn.suggestedActions,
           timestamp: new Date().toISOString(),
         })
       }
@@ -926,6 +929,7 @@ export function AskPage({ onError }: Readonly<AskPageProps>) {
                 sql: response.sql,
                 evidence: response.raw_results ?? [],
                 rowCount: response.row_count,
+                suggestedActions: response.suggested_actions,
               }
             : turn,
         )
@@ -1070,6 +1074,25 @@ export function AskPage({ onError }: Readonly<AskPageProps>) {
                               source={turn.source}
                               rowCount={turn.rowCount}
                             />
+                            {turn.suggestedActions && turn.suggestedActions.length > 0 && (
+                              <div className="flex flex-wrap gap-1.5 mt-3 pt-3 border-t border-gray-100">
+                                {turn.suggestedActions.map((action, i) => (
+                                  <a
+                                    key={i}
+                                    href={action.action_type === 'navigate' ? action.target : undefined}
+                                    onClick={(e) => {
+                                      if (action.action_type === 'ask') {
+                                        e.preventDefault()
+                                        setDraft(action.target)
+                                      }
+                                    }}
+                                    className="inline-flex items-center gap-1 px-2.5 py-1 rounded-lg text-xs font-medium border border-gray-200 text-gray-600 hover:border-primary hover:text-primary transition-colors cursor-pointer no-underline"
+                                  >
+                                    {action.label}
+                                  </a>
+                                ))}
+                              </div>
+                            )}
                           </div>
                         )}
                       </div>

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
 import {
   Upload, ShoppingCart, Boxes, Users, FileText, CheckCircle,
   Clock, ShoppingBag, Store, AlertTriangle, Calendar, BarChart3, FolderOpen,
+  Lightbulb, Bot, TableProperties, X,
 } from 'lucide-react'
 import { analytics, inventory, vendors, documents } from '@/lib/api'
 import type { Vendor, DashboardStats } from '@/lib/api'
@@ -31,6 +32,9 @@ const DOC_BAR_CLASSES = [
 
 export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
   const navigate = useNavigate()
+  const [showOnboarding, setShowOnboarding] = useState(
+    () => !localStorage.getItem('labclaw_onboarding_dismissed'),
+  )
 
   const { data: stats, error: statsErr, isLoading: statsLoading } = useQuery({
     queryKey: ['dashboard'],
@@ -143,6 +147,42 @@ export function DashboardPage({ onError }: Readonly<DashboardPageProps>) {
 
   return (
     <div className="space-y-8">
+      {/* Onboarding banner for new users */}
+      {showOnboarding && (
+        <div className="rounded-xl border border-primary/20 bg-primary/5 p-5">
+          <div className="flex items-start gap-4">
+            <Lightbulb className="size-6 text-primary mt-0.5 shrink-0" />
+            <div className="flex-1">
+              <h3 className="text-sm font-semibold text-[var(--foreground)] mb-2">Getting Started</h3>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-xs text-[var(--muted-foreground)]">
+                <div className="flex items-start gap-2">
+                  <Bot className="size-4 text-primary mt-0.5 shrink-0" />
+                  <span>Use <strong>Ask AI</strong> to query your lab in plain English — &quot;Do we have acetone?&quot;</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <Upload className="size-4 text-primary mt-0.5 shrink-0" />
+                  <span>Upload packing lists or invoices — AI extracts the data automatically</span>
+                </div>
+                <div className="flex items-start gap-2">
+                  <TableProperties className="size-4 text-primary mt-0.5 shrink-0" />
+                  <span>Import existing data from Excel/CSV via the Upload page</span>
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                localStorage.setItem('labclaw_onboarding_dismissed', '1')
+                setShowOnboarding(false)
+              }}
+              className="shrink-0 p-1 rounded hover:bg-[var(--border)] transition-colors text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+              title="Dismiss"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* Quick Actions Row */}
       <div className="mb-8">
         <h3 className="text-[var(--muted-foreground)] text-[10px] font-bold uppercase tracking-widest mb-4">Quick Actions</h3>

--- a/web/src/pages/ReviewPage.tsx
+++ b/web/src/pages/ReviewPage.tsx
@@ -257,6 +257,13 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                     {Math.round((docDetail.extraction_confidence ?? 0) * 100)}%)
                   </span>
                 )}
+                {docDetail.extraction_confidence != null && docDetail.extraction_confidence < 0.8 && (
+                  <span className="text-[10px] text-[var(--muted-foreground)] italic max-w-xs">
+                    {docDetail.extraction_confidence >= 0.6
+                      ? 'Some fields may need verification'
+                      : 'AI models disagreed — please verify each field'}
+                  </span>
+                )}
                 {docDetail.extraction_model && (
                   <>
                     <div className="h-4 w-px bg-[var(--border)]" />
@@ -591,6 +598,17 @@ export function ReviewPage({ onError }: ReviewPageProps) {
                   </button>
                 </div>
               </div>
+            </div>
+          )}
+
+          {/* Approve preview */}
+          {docDetail?.extracted_data && (
+            <div className="mx-4 mb-1 p-2.5 rounded-lg bg-emerald-50 border border-emerald-100 text-[11px] text-emerald-700">
+              <strong>Approve will:</strong> Create 1 order from{' '}
+              <strong>{docDetail.extracted_data.vendor_name || 'unknown vendor'}</strong>
+              {(docDetail.extracted_data.items?.length ?? 0) > 0 && (
+                <> with {docDetail.extracted_data.items?.length} line item{(docDetail.extracted_data.items?.length ?? 0) !== 1 ? 's' : ''} added to inventory</>
+              )}
             </div>
           )}
 


### PR DESCRIPTION
## Summary

React frontend improvements to make the app more accessible for scientists (non-CS users). All changes are in `web/src/` — no legacy static/ modifications.

### Changes:

**api.ts** — New types and API bindings:
- `SuggestedAction` type for /ask endpoint enhanced response
- `ImportResult` / `BatchResult` types for new backend endpoints
- `bulkImport.products()` / `bulkImport.vendors()` — CSV upload
- `vendorOps.merge()` — vendor deduplication
- `batchInventory.consume()` / `batchInventory.dispose()` — batch ops

**AskPage.tsx** — Suggested actions:
- Stores `suggestedActions` from API response in chat turns
- Renders clickable follow-up buttons below AI answers (e.g. "View expiring inventory", "Export orders CSV")
- Navigate actions link to relevant pages, ask actions pre-fill the input

**DashboardPage.tsx** — Onboarding:
- Dismissible getting-started banner for new users
- Tips: Ask AI, upload documents, CSV import
- Persists dismissal in localStorage (`labclaw_onboarding_dismissed`)

**ReviewPage.tsx** — Confidence UX:
- Plain-language explanation for medium/low confidence ("Some fields may need verification" / "AI models disagreed")
- Approve preview bar showing "Approve will: Create 1 order from Vendor X with N line items"

## Test plan

- [ ] AskPage: ask a question → verify suggested action buttons appear below answer
- [ ] AskPage: click a "navigate" action → verify navigation works
- [ ] DashboardPage: verify onboarding banner appears on first visit
- [ ] DashboardPage: dismiss banner → refresh → verify it stays hidden
- [ ] ReviewPage: select a low-confidence doc → verify explanation text
- [ ] ReviewPage: verify approve preview text shows vendor name and item count
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint` passes on changed files

https://claude.ai/code/session_0198cc91V7TZZWrHE6Sra4KM