### PR TITLE
fix(security): add RBAC permission guards to alerts and telemetry routes

### DIFF
--- a/src/lab_manager/api/routes/alerts.py
+++ b/src/lab_manager/api/routes/alerts.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from lab_manager.api.auth import require_permission
 from lab_manager.api.deps import get_db, get_or_404
 from lab_manager.api.pagination import paginate
 from lab_manager.models.alert import Alert
@@ -50,7 +51,7 @@ def alert_summary(db: Session = Depends(get_db)):
     return get_alert_summary(db)
 
 
-@router.post("/check")
+@router.post("/check", dependencies=[Depends(require_permission("manage_alerts"))])
 def run_alert_check(request: Request, db: Session = Depends(get_db)):
     """Trigger alert checks, persist new alerts, return summary.
 
@@ -64,7 +65,10 @@ def run_alert_check(request: Request, db: Session = Depends(get_db)):
     }
 
 
-@router.post("/{alert_id}/acknowledge")
+@router.post(
+    "/{alert_id}/acknowledge",
+    dependencies=[Depends(require_permission("acknowledge_alerts"))],
+)
 def acknowledge_alert(
     alert_id: int,
     acknowledged_by: Optional[str] = Query(None),
@@ -80,7 +84,9 @@ def acknowledge_alert(
     return alert
 
 
-@router.post("/{alert_id}/resolve")
+@router.post(
+    "/{alert_id}/resolve", dependencies=[Depends(require_permission("manage_alerts"))]
+)
 def resolve_alert(
     alert_id: int,
     db: Session = Depends(get_db),

--- a/src/lab_manager/api/routes/telemetry.py
+++ b/src/lab_manager/api/routes/telemetry.py
@@ -10,10 +10,11 @@ from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy import func, select, text
 from sqlalchemy.orm import Session
 
+from lab_manager.api.auth import require_permission
 from lab_manager.api.deps import get_db
 from lab_manager.models.usage_event import UsageEvent
 
-router = APIRouter()
+router = APIRouter(dependencies=[Depends(require_permission("view_analytics"))])
 
 # In-memory rate limiting: 1 event per user per page per minute
 _rate_limits: dict[str, float] = {}


### PR DESCRIPTION
## Summary
- Add `manage_alerts` permission guard to `POST /alerts/check` and `POST /alerts/{id}/resolve`
- Add `acknowledge_alerts` permission guard to `POST /alerts/{id}/acknowledge`
- Add `view_analytics` router-level guard to all telemetry endpoints

## Test plan
- [x] `pytest tests/test_rbac_permissions.py` — 42 passed
- [x] `ruff check` — all checks passed
- [ ] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)