### PR TITLE
fix(web): use alert_type instead of type in Header

### DIFF
--- a/alembic/versions/0c2125df7c3a_merge_heads.py
+++ b/alembic/versions/0c2125df7c3a_merge_heads.py
@@ -1,0 +1,27 @@
+"""merge heads
+
+Revision ID: 0c2125df7c3a
+Revises: a0b1c2d3e4f5, a1b2c3d4e5f6, a2b3c4d5e6f7
+Create Date: 2026-03-26 12:12:09.806343
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0c2125df7c3a'
+down_revision: Union[str, None] = ('a0b1c2d3e4f5', 'a1b2c3d4e5f6', 'a2b3c4d5e6f7')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -186,7 +186,7 @@ export function Header({ title, onSearch, showSearch = true, onMobileMenuToggle,
                   >
                     <div className="flex items-center gap-2">
                       <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${a.severity === 'critical' ? 'bg-red-500' : a.severity === 'warning' ? 'bg-yellow-500' : 'bg-blue-500'}`} />
-                      <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase">{a.type}</span>
+                      <span className="text-xs font-medium text-[var(--muted-foreground)] uppercase">{a.alert_type}</span>
                     </div>
                     <p className="text-sm text-[var(--foreground)] mt-1 line-clamp-2">{a.message}</p>
                   </div>


### PR DESCRIPTION
## Summary
- Fix TypeScript error in Header.tsx where `a.type` should be `a.alert_type`
- Add alembic merge migration for multiple heads

## Test plan
- [x] Deployment verified at http://159.89.84.58
- [x] Admin login accessible at /admin/login
- [x] Frontend loads correctly
- [x] All containers healthy (app, caddy, db, search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)