### PR TITLE
fix(web): product polish — title, dead buttons, coming soon states

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Lab Manager</title>
+    <meta name="description" content="AI-powered lab inventory management. Upload documents, track supplies, manage orders." />
+    <title>LabClaw Lab Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/pages/ScanPage.tsx
+++ b/web/src/pages/ScanPage.tsx
@@ -235,7 +235,7 @@ function ScanResultCard({ item }: { readonly item: InventoryItem }) {
         </a>
         <button
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-emerald-500/10 text-emerald-600 text-xs font-medium hover:bg-emerald-500/20 transition-colors"
-          title="Log consumption (coming soon)"
+          title="Log consumption"
         >
           <Beaker className="size-3.5" />
           Log Consumption

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -535,7 +535,7 @@ export function SettingsPage({ onError }: Readonly<SettingsPageProps>) {
             description="Download all data tables as CSV files"
           />
 
-          <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg bg-gray-50/50">
+          <div className="flex items-center justify-between p-3 border border-gray-200 rounded-lg bg-gray-50/50 cursor-not-allowed opacity-50">
             <div className="flex items-center gap-3">
               <AlertTriangle className="size-4 text-gray-300" />
               <div>
@@ -543,10 +543,9 @@ export function SettingsPage({ onError }: Readonly<SettingsPageProps>) {
                 <p className="text-xs text-gray-400">Restore all settings to factory defaults</p>
               </div>
             </div>
-            <ComingSoon />
           </div>
 
-          <div className="flex items-center justify-between p-3 border border-red-200 rounded-lg bg-red-50/30">
+          <div className="flex items-center justify-between p-3 border border-red-200 rounded-lg bg-red-50/30 cursor-not-allowed opacity-50">
             <div className="flex items-center gap-3">
               <AlertTriangle className="size-4 text-red-300" />
               <div>
@@ -554,7 +553,6 @@ export function SettingsPage({ onError }: Readonly<SettingsPageProps>) {
                 <p className="text-xs text-red-300">Permanently remove all documents, orders, and inventory</p>
               </div>
             </div>
-            <ComingSoon />
           </div>
         </div>
       </SectionCard>

--- a/web/src/pages/UploadPage.tsx
+++ b/web/src/pages/UploadPage.tsx
@@ -370,7 +370,10 @@ export function UploadPage() {
                     </button>
                   </div>
                 ) : record.status === 'uploading' ? (
-                  <button className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
+                  <button
+                    className="p-2 text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+                    onClick={() => setUploads((prev) => prev.map((u) => u.id === record.id ? { ...u, status: 'failed', error: 'Cancelled' } : u))}
+                  >
                     <X />
                   </button>
                 ) : (


### PR DESCRIPTION
## Summary
- Update `<title>` to "LabClaw Lab Manager" and add meta description for SEO
- Fix dead cancel (X) button on UploadPage during upload state — now sets file status to failed/cancelled
- Remove "(coming soon)" from ScanPage log consumption tooltip
- Replace "Coming Soon" badges with disabled visual state (opacity + cursor-not-allowed) in Settings danger zone

## Test plan
- [ ] Verify page title shows "LabClaw Lab Manager" in browser tab
- [ ] Upload a file, confirm X button cancels the upload row
- [ ] Scan a barcode, confirm "Log Consumption" button tooltip has no "coming soon"
- [ ] Open Settings, scroll to Danger Zone, confirm buttons appear greyed out without "Coming Soon" text

Generated with [Claude Code](https://claude.com/claude-code)