### PR TITLE
chore: add paper/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ docs/pipeline-results-summary.md
 docs/audit_analysis_report.md
 docs/comprehensive-research-report.md
 paper/
+paper/


### PR DESCRIPTION
Prevent unpublished manuscript files from being accidentally committed to the public repo.