### PR TITLE
fix(meta): align version to 0.1.11 across VERSION, pyproject.toml, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Security](https://github.com/labclaw/lab-manager/actions/workflows/security.yml/badge.svg)](https://github.com/labclaw/lab-manager/actions/workflows/security.yml)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
-[![Version](https://img.shields.io/badge/version-0.1.9-green.svg)](https://github.com/labclaw/lab-manager/releases)
+[![Version](https://img.shields.io/badge/version-0.1.11-green.svg)](https://github.com/labclaw/lab-manager/releases)
+[![Version](https://img.shields.io/badge/version-0.1.11-green.svg)](https://github.com/labclaw/lab-manager/releases)
 
 Lab Manager is a lab operations app for research groups that need one place to receive supplies, review scanned documents, track inventory, and keep an audit trail.
 
@@ -17,13 +18,15 @@ Core flow:
 
 ## Release Status
 
-`v0.1.9` is the current stable internal release. The maintained backend, database model, setup wizard, login flow, review queue, inventory lifecycle, export, search, and admin surface are validated on the release-critical suite and real-user smoke flows.
+`v0.1.11` is the current stable internal release. The maintained backend, database model, setup wizard, login flow, review queue, inventory lifecycle, export, search, and admin surface are validated on the release-critical suite and real-user smoke flows.
+`v0.1.11` is the current stable internal release. The maintained backend, database model, setup wizard, login flow, review queue, inventory lifecycle, export, search, and admin surface are validated on the release-critical suite and real-user smoke flows.
 
 The React frontend in [`web/`](web/) is an in-progress replacement, not the default release surface. The shipped app currently relies on the backend-served UI under [`src/lab_manager/static/`](src/lab_manager/static/).
 
 ## Release Gate
 
-`v0.1.9` is release-gated by an explicit maintained suite, not by the full historical test tree.
+`v0.1.11` is release-gated by an explicit maintained suite, not by the full historical test tree.
+`v0.1.11` is release-gated by an explicit maintained suite, not by the full historical test tree.
 
 Required checks:
 - `uv sync --dev --frozen`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lab-manager"
-version = "0.1.10"
+version = "0.1.11"
 description = "Lab inventory management with OCR document intake"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
VERSION file said 0.1.11, pyproject.toml said 0.1.10, README badge said 0.1.9.
All now consistently reference v0.1.11.