### PR TITLE
[codex] fix security alerts

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -25,6 +25,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 import lab_manager.services.audit as _audit_svc  # noqa: F401
 from lab_manager.api.admin import setup_admin
 from lab_manager.api.deps import get_db
+from lab_manager.api.validation import is_valid_email_address
 from lab_manager.config import get_settings
 from lab_manager.database import get_engine
 from lab_manager.exceptions import BusinessError
@@ -707,7 +708,7 @@ def create_app() -> FastAPI:
                 status_code=422,
                 content={"detail": "Name must be between 1 and 200 characters"},
             )
-        if not re.match(r"^[^@\s]+@[^@\s]+\.[^@\s]+$", admin_email):
+        if not is_valid_email_address(admin_email):
             return JSONResponse(
                 status_code=422,
                 content={"detail": "Invalid email address"},

--- a/src/lab_manager/api/routes/email_ingest.py
+++ b/src/lab_manager/api/routes/email_ingest.py
@@ -92,10 +92,11 @@ async def _handle_json_email(
     try:
         body = await request.json()
         payload = EmailIngestPayload(**body)
-    except Exception as e:
+    except Exception:
+        logger.warning("Rejected invalid JSON email ingest payload", exc_info=True)
         return JSONResponse(
             status_code=422,
-            content={"detail": f"Invalid JSON payload: {e}"},
+            content={"detail": "Invalid JSON payload"},
         )
 
     if not payload.attachments:

--- a/src/lab_manager/api/routes/team.py
+++ b/src/lab_manager/api/routes/team.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import re
 import secrets
 from datetime import datetime, timezone
 from typing import Optional
@@ -17,6 +16,7 @@ from sqlalchemy.orm import Session
 from lab_manager.api.auth import ROLE_LEVELS, get_permissions, require_permission
 from lab_manager.api.deps import get_db
 from lab_manager.api.pagination import paginate
+from lab_manager.api.validation import is_valid_email_address
 from lab_manager.config import get_settings
 from lab_manager.models.invitation import Invitation
 from lab_manager.models.staff import Staff
@@ -27,9 +27,6 @@ router = APIRouter()
 
 # Invitation tokens expire after 7 days (seconds).
 _INVITE_MAX_AGE = 7 * 24 * 3600
-
-_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
-
 
 def _get_invite_serializer() -> URLSafeTimedSerializer:
     settings = get_settings()
@@ -79,7 +76,7 @@ def create_invitation(
         raise HTTPException(
             status_code=422, detail="Name must be between 1 and 200 characters"
         )
-    if not _EMAIL_RE.match(email) or len(email) > 255:
+    if not is_valid_email_address(email):
         raise HTTPException(status_code=422, detail="Invalid email address")
     if role not in ROLE_LEVELS:
         raise HTTPException(status_code=422, detail=f"Invalid role: {role}")

--- a/src/lab_manager/api/validation.py
+++ b/src/lab_manager/api/validation.py
@@ -1,0 +1,38 @@
+"""Small request-validation helpers shared across API routes."""
+
+from __future__ import annotations
+
+import string
+
+_EMAIL_LOCAL_CHARS = set(string.ascii_letters + string.digits + "!#$%&'*+/=?^_`{|}~.-")
+_EMAIL_DOMAIN_CHARS = set(string.ascii_letters + string.digits + "-")
+
+
+def is_valid_email_address(value: str) -> bool:
+    """Return True for a conservative ASCII email address format."""
+    if not value or len(value) > 255 or any(ch.isspace() for ch in value):
+        return False
+
+    local_part, separator, domain = value.rpartition("@")
+    if separator != "@" or not local_part or not domain:
+        return False
+    if "." not in domain:
+        return False
+    if local_part.startswith(".") or local_part.endswith(".") or ".." in local_part:
+        return False
+    if domain.startswith(".") or domain.endswith(".") or ".." in domain:
+        return False
+    if any(ch not in _EMAIL_LOCAL_CHARS for ch in local_part):
+        return False
+
+    labels = domain.split(".")
+    if any(not label for label in labels):
+        return False
+
+    for label in labels:
+        if label.startswith("-") or label.endswith("-"):
+            return False
+        if any(ch not in _EMAIL_DOMAIN_CHARS for ch in label):
+            return False
+
+    return True

--- a/src/lab_manager/config.py
+++ b/src/lab_manager/config.py
@@ -76,9 +76,8 @@ class Settings(BaseSettings):
                 )
             elif pw.startswith("changeme"):
                 logger.warning(
-                    "ADMIN_PASSWORD is still a default value (%s). "
-                    "Change it to a strong password before deploying.",
-                    pw,
+                    "ADMIN_PASSWORD is still set to a default-style value. "
+                    "Change it to a strong password before deploying."
                 )
         return self
 

--- a/src/lab_manager/services/email_poller.py
+++ b/src/lab_manager/services/email_poller.py
@@ -22,25 +22,28 @@ DEFAULT_POLL_INTERVAL = 300
 
 
 def _get_imap_config() -> dict:
-    """Read IMAP configuration from environment."""
+    """Read non-secret IMAP configuration from environment."""
     host = os.environ.get("EMAIL_IMAP_HOST", "")
     user = os.environ.get("EMAIL_IMAP_USER", "")
-    password = os.environ.get("EMAIL_IMAP_PASSWORD", "")
     folder = os.environ.get("EMAIL_FOLDER", "INBOX")
     interval = int(os.environ.get("EMAIL_POLL_INTERVAL", str(DEFAULT_POLL_INTERVAL)))
     return {
         "host": host,
         "user": user,
-        "password": password,
         "folder": folder,
         "interval": interval,
     }
 
 
-def _connect_imap(config: dict) -> imaplib.IMAP4_SSL:
+def _get_imap_password() -> str:
+    """Read the IMAP password from the environment."""
+    return os.environ.get("EMAIL_IMAP_PASSWORD", "")
+
+
+def _connect_imap(config: dict, password: str) -> imaplib.IMAP4_SSL:
     """Connect and authenticate to IMAP server."""
     conn = imaplib.IMAP4_SSL(config["host"])
-    conn.login(config["user"], config["password"])
+    conn.login(config["user"], password)
     return conn
 
 
@@ -76,13 +79,17 @@ def poll_once() -> int:
     from lab_manager.services.email_intake import process_email
 
     config = _get_imap_config()
+    password = _get_imap_password()
     if not config["host"] or not config["user"]:
         logger.debug("Email polling not configured (missing EMAIL_IMAP_HOST/USER)")
+        return 0
+    if not password:
+        logger.debug("Email polling not configured (missing EMAIL_IMAP_PASSWORD)")
         return 0
 
     total_docs = 0
     try:
-        conn = _connect_imap(config)
+        conn = _connect_imap(config, password)
         try:
             raw_emails = _fetch_unseen_emails(conn, config["folder"])
             logger.info(
@@ -115,10 +122,14 @@ def run_poller() -> None:
     Intended to be started in a background thread or separate process.
     """
     config = _get_imap_config()
+    password = _get_imap_password()
     if not config["host"] or not config["user"]:
         logger.warning(
             "Email poller not starting: EMAIL_IMAP_HOST and EMAIL_IMAP_USER required"
         )
+        return
+    if not password:
+        logger.warning("Email poller not starting: EMAIL_IMAP_PASSWORD required")
         return
 
     interval = config["interval"]

--- a/tests/test_vendor_urls.py
+++ b/tests/test_vendor_urls.py
@@ -1,8 +1,37 @@
 """Tests for vendor URL registry and reorder URL generation."""
 
+from urllib.parse import parse_qs, urlparse
+
 import pytest
 
 from lab_manager.services.vendor_urls import VENDOR_SEARCH_URLS, get_reorder_url
+
+
+def _assert_https_host(url: str, expected_host: str):
+    parsed = urlparse(url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == expected_host
+    return parsed
+
+
+def _assert_query_param(url: str, expected_host: str, key: str, expected_value: str):
+    parsed = _assert_https_host(url, expected_host)
+    assert parse_qs(parsed.query).get(key) == [expected_value]
+    return parsed
+
+
+@pytest.fixture
+def client_without_search(client, monkeypatch):
+    monkeypatch.setattr(
+        "lab_manager.api.routes.vendors.index_vendor_record", lambda _: None
+    )
+    monkeypatch.setattr(
+        "lab_manager.api.routes.products.index_product_record", lambda _: None
+    )
+    monkeypatch.setattr(
+        "lab_manager.api.routes.inventory.index_inventory_record", lambda _: None
+    )
+    return client
 
 
 class TestVendorSearchUrls:
@@ -38,35 +67,42 @@ class TestGetReorderUrl:
     def test_substring_match_vendor_in_key(self):
         url = get_reorder_url("Bio-Rad Laboratories", "1234567")
         assert url is not None
-        assert "1234567" in url
+        parsed = _assert_query_param(url, "www.bio-rad.com", "query", "1234567")
+        assert parsed.path == "/en-us/search"
 
     def test_substring_match_key_in_vendor(self):
         url = get_reorder_url("VWR", "ABC-123")
         assert url is not None
-        assert "ABC-123" in url
+        parsed = _assert_query_param(url, "us.vwr.com", "query", "ABC-123")
+        assert parsed.path == "/store/search"
 
     def test_case_insensitive(self):
         url = get_reorder_url("ADDGENE", "12345")
         assert url is not None
-        assert "addgene.org" in url
+        parsed = _assert_query_param(url, "www.addgene.org", "q", "12345")
+        assert parsed.path == "/search/all/"
 
     def test_invitrogen_maps_to_thermofisher(self):
         url = get_reorder_url("Invitrogen", "INV-001")
         assert url is not None
-        assert "thermofisher.com" in url
-        assert "INV-001" in url
+        _assert_query_param(url, "www.thermofisher.com", "query", "INV-001")
 
     def test_milliporesigma_maps_to_sigmaaldrich(self):
         url = get_reorder_url("MilliporeSigma", "M5678")
         assert url is not None
-        assert "sigmaaldrich.com" in url
+        parsed = _assert_https_host(url, "www.sigmaaldrich.com")
+        assert parsed.path.split("/")[-1] == "M5678"
 
     def test_unknown_vendor_falls_back_to_google(self):
         url = get_reorder_url("Unknown Vendor Inc", "XYZ-999")
         assert url is not None
-        assert "google.com/search" in url
-        assert "Unknown Vendor Inc" in url
-        assert "XYZ-999" in url
+        parsed = _assert_query_param(
+            url,
+            "www.google.com",
+            "q",
+            "Unknown Vendor Inc XYZ-999 order",
+        )
+        assert parsed.path == "/search"
 
     def test_empty_vendor_returns_none(self):
         assert get_reorder_url("", "S1234") is None
@@ -84,20 +120,22 @@ class TestGetReorderUrl:
     def test_mcmaster_carr(self):
         url = get_reorder_url("McMaster-Carr", "91251A")
         assert url is not None
-        assert "mcmaster.com" in url
-        assert "91251A" in url
+        parsed = _assert_https_host(url, "www.mcmaster.com")
+        assert parsed.path.strip("/") == "91251A"
 
 
 class TestGetReorderUrlEndpoint:
     """Test the API endpoint for reorder URL generation."""
 
-    def test_reorder_url_with_known_vendor(self, client):
+    def test_reorder_url_with_known_vendor(self, client_without_search):
         # Create vendor
-        vr = client.post("/api/v1/vendors/", json={"name": "Sigma-Aldrich"})
+        vr = client_without_search.post(
+            "/api/v1/vendors/", json={"name": "Sigma-Aldrich"}
+        )
         vendor_id = vr.json()["id"]
 
         # Create product
-        pr = client.post(
+        pr = client_without_search.post(
             "/api/v1/products/",
             json={
                 "name": "Test Chemical",
@@ -108,26 +146,28 @@ class TestGetReorderUrlEndpoint:
         product_id = pr.json()["id"]
 
         # Create inventory item
-        ir = client.post(
+        ir = client_without_search.post(
             "/api/v1/inventory/",
             json={"product_id": product_id, "quantity_on_hand": 5},
         )
         item_id = ir.json()["id"]
 
         # Get reorder URL
-        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        resp = client_without_search.get(f"/api/v1/inventory/{item_id}/reorder-url")
         assert resp.status_code == 200
         data = resp.json()
         assert data["vendor"] == "Sigma-Aldrich"
         assert data["catalog_number"] == "S1234"
-        assert "sigmaaldrich.com" in data["url"]
-        assert "S1234" in data["url"]
+        parsed = _assert_https_host(data["url"], "www.sigmaaldrich.com")
+        assert parsed.path.split("/")[-1] == "S1234"
 
-    def test_reorder_url_unknown_vendor_google_fallback(self, client):
-        vr = client.post("/api/v1/vendors/", json={"name": "Unknown Lab Supply"})
+    def test_reorder_url_unknown_vendor_google_fallback(self, client_without_search):
+        vr = client_without_search.post(
+            "/api/v1/vendors/", json={"name": "Unknown Lab Supply"}
+        )
         vendor_id = vr.json()["id"]
 
-        pr = client.post(
+        pr = client_without_search.post(
             "/api/v1/products/",
             json={
                 "name": "Mystery Reagent",
@@ -137,32 +177,38 @@ class TestGetReorderUrlEndpoint:
         )
         product_id = pr.json()["id"]
 
-        ir = client.post(
+        ir = client_without_search.post(
             "/api/v1/inventory/",
             json={"product_id": product_id, "quantity_on_hand": 1},
         )
         item_id = ir.json()["id"]
 
-        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        resp = client_without_search.get(f"/api/v1/inventory/{item_id}/reorder-url")
         assert resp.status_code == 200
         data = resp.json()
-        assert "google.com/search" in data["url"]
+        parsed = _assert_query_param(
+            data["url"],
+            "www.google.com",
+            "q",
+            "Unknown Lab Supply UNK-001 order",
+        )
+        assert parsed.path == "/search"
 
-    def test_reorder_url_no_vendor_returns_none(self, client):
+    def test_reorder_url_no_vendor_returns_none(self, client_without_search):
         # Product with no vendor
-        pr = client.post(
+        pr = client_without_search.post(
             "/api/v1/products/",
             json={"name": "Orphan Product", "catalog_number": "ORP-001"},
         )
         product_id = pr.json()["id"]
 
-        ir = client.post(
+        ir = client_without_search.post(
             "/api/v1/inventory/",
             json={"product_id": product_id, "quantity_on_hand": 1},
         )
         item_id = ir.json()["id"]
 
-        resp = client.get(f"/api/v1/inventory/{item_id}/reorder-url")
+        resp = client_without_search.get(f"/api/v1/inventory/{item_id}/reorder-url")
         assert resp.status_code == 200
         data = resp.json()
         assert data["url"] is None


### PR DESCRIPTION
## What changed
This PR fixes the open CodeQL security findings on the default branch.

It replaces regex-based email validation in setup and team invite flows with a shared conservative validator, removes sensitive password values from warning logs, avoids returning raw JSON parsing exceptions to API clients, and rewrites vendor URL tests to validate parsed URL components instead of substring checks.

## Why
The default branch had open CodeQL findings for:
- clear-text logging of sensitive data
- polynomial regex denial-of-service risk
- stack-trace exposure in API responses
- incomplete URL substring sanitization in tests

## Impact
These changes reduce sensitive-data exposure in logs, remove the flagged email-validation regex usage, stop leaking raw exception details to clients, and align URL tests with host/query/path validation.

## Validation
Local validation completed in the original checkout with:
- `uv run pytest tests/test_setup.py tests/test_team.py tests/test_email_intake.py tests/test_vendor_urls.py`

The clean PR worktree hit an unrelated local Python 3.13/admin-fixture issue in part of `tests/test_team.py`, so the protected GitHub checks are the source of truth for merge gating.
