### PR TITLE
fix(validation): reject empty vendor names in create and update

### DIFF
--- a/src/lab_manager/api/routes/vendors.py
+++ b/src/lab_manager/api/routes/vendors.py
@@ -26,7 +26,7 @@ _VENDOR_SORTABLE = {"id", "created_at", "updated_at", "name", "email", "website"
 
 
 class VendorCreate(BaseModel):
-    name: str = Field(max_length=255)
+    name: str = Field(min_length=1, max_length=255)
     aliases: list[str] = []
     website: Optional[str] = Field(default=None, max_length=500)
     phone: Optional[str] = Field(default=None, max_length=50)
@@ -35,7 +35,7 @@ class VendorCreate(BaseModel):
 
 
 class VendorUpdate(BaseModel):
-    name: Optional[str] = Field(default=None, max_length=255)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=255)
     aliases: Optional[list[str]] = None
     website: Optional[str] = Field(default=None, max_length=500)
     phone: Optional[str] = Field(default=None, max_length=50)

--- a/tests/test_api_vendors.py
+++ b/tests/test_api_vendors.py
@@ -29,3 +29,17 @@ def test_list_vendors(client):
 def test_get_vendor_not_found(client):
     resp = client.get("/api/v1/vendors/999")
     assert resp.status_code == 404
+
+
+def test_create_vendor_empty_name_rejected(client):
+    """Empty vendor name should be rejected by validation."""
+    resp = client.post("/api/v1/vendors/", json={"name": ""})
+    assert resp.status_code == 422
+
+
+def test_update_vendor_empty_name_rejected(client):
+    """Updating vendor name to empty string should be rejected."""
+    created = client.post("/api/v1/vendors/", json={"name": "TestVendor"})
+    vendor_id = created.json()["id"]
+    resp = client.patch(f"/api/v1/vendors/{vendor_id}", json={"name": ""})
+    assert resp.status_code == 422


### PR DESCRIPTION
## Bug
`VendorCreate.name` and `VendorUpdate.name` accepted empty strings (`""`). Since `Vendor.name` has a UNIQUE constraint, two vendors with empty names would cause a PostgreSQL 500 error instead of a proper 422 validation response.

## Root Cause
`Field(max_length=255)` with no `min_length` — Pydantic allows empty strings by default.

## Fix
Added `min_length=1` to both `VendorCreate.name` and `VendorUpdate.name`.

## Test
- `test_create_vendor_empty_name_rejected` — POST with `{"name": ""}` returns 422
- `test_update_vendor_empty_name_rejected` — PATCH with `{"name": ""}` returns 422

All 6 vendor tests pass.

🤖 Found and fixed by `/bug-hunter` autonomous loop.