### PR TITLE
fix(tests): unwrap order response in analytics BDD tests

### DIFF
--- a/tests/bdd/step_defs/test_analytics.py
+++ b/tests/bdd/step_defs/test_analytics.py
@@ -149,7 +149,7 @@ def create_vendor_with_priced_items(api, name):
         },
     )
     assert r.status_code == 201, r.text
-    order = r.json()
+    order = r.json()["order"]
 
     r = api.post(
         f"/api/v1/orders/{order['id']}/items",
@@ -184,7 +184,7 @@ def create_vendor_with_ordered_products(api, name):
         },
     )
     assert r.status_code == 201, r.text
-    order = r.json()
+    order = r.json()["order"]
 
     for i in range(3):
         r = api.post(


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'id'` in `test_spending_by_vendor` and `test_top_products` BDD tests
- Order creation endpoint returns `{"order": ..., "_duplicate_warning": ...}` but tests accessed `r.json()` directly
- Changed `order = r.json()` → `order = r.json()["order"]` in two step definitions

## Test plan
- [x] `test_spending_by_vendor` passes
- [x] `test_top_products` passes
- [x] All other analytics tests pass (10/11 — `test_doc_processing_stats` has a separate pre-existing issue with file path validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)