### PR TITLE
fix(tests): use relative file_path in analytics doc stats test

### DIFF
--- a/tests/bdd/step_defs/test_analytics.py
+++ b/tests/bdd/step_defs/test_analytics.py
@@ -263,7 +263,7 @@ def create_docs_for_analytics(api, n):
             "/api/v1/documents/",
             json={
                 "file_name": f"analytics_doc_{i}.jpg",
-                "file_path": f"/uploads/analytics_doc_{i}.jpg",
+                "file_path": f"uploads/analytics_doc_{i}.jpg",
                 "status": "approved",
             },
         )


### PR DESCRIPTION
## Summary
- Fix `test_doc_processing_stats` failure (422 on absolute file path)
- Changed `file_path` from `/uploads/...` (absolute, rejected by validator) to `uploads/...` (relative, resolves under upload_dir)
- Matches the pattern used by all other passing document creation tests

## Test plan
- [x] `test_doc_processing_stats` now passes
- [x] All other analytics BDD tests pass (11/11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)