### PR TITLE
fix(equipment): reject empty name in create and update

### DIFF
--- a/src/lab_manager/api/routes/equipment.py
+++ b/src/lab_manager/api/routes/equipment.py
@@ -38,7 +38,7 @@ _VALID_EQUIPMENT_STATUSES = {
 
 
 class EquipmentCreate(BaseModel):
-    name: str = Field(max_length=500)
+    name: str = Field(min_length=1, max_length=500)
     manufacturer: Optional[str] = Field(default=None, max_length=255)
     model: Optional[str] = Field(default=None, max_length=255)
     serial_number: Optional[str] = Field(default=None, max_length=255)
@@ -65,7 +65,7 @@ class EquipmentCreate(BaseModel):
 
 
 class EquipmentUpdate(BaseModel):
-    name: Optional[str] = Field(default=None, max_length=500)
+    name: Optional[str] = Field(default=None, min_length=1, max_length=500)
     manufacturer: Optional[str] = Field(default=None, max_length=255)
     model: Optional[str] = Field(default=None, max_length=255)
     serial_number: Optional[str] = Field(default=None, max_length=255)

--- a/tests/test_equipment.py
+++ b/tests/test_equipment.py
@@ -24,6 +24,18 @@ def test_create_equipment(client):
     assert data["id"] is not None
 
 
+def test_create_equipment_empty_name_rejected(client):
+    r = client.post("/api/v1/equipment/", json={"name": ""})
+    assert r.status_code == 422
+
+
+def test_update_equipment_empty_name_rejected(client):
+    r = client.post("/api/v1/equipment/", json={"name": "Valid", "category": "x"})
+    eid = r.json()["id"]
+    r = client.patch(f"/api/v1/equipment/{eid}", json={"name": ""})
+    assert r.status_code == 422
+
+
 def test_get_equipment(client):
     r = client.post(
         "/api/v1/equipment/",


### PR DESCRIPTION
## Summary
- Add `min_length=1` to `EquipmentCreate.name` and `EquipmentUpdate.name`
- Prevents blank-name equipment records from entering the database
- Same pattern as vendor name validation fix (#304)

## Test plan
- [x] New test: `test_create_equipment_empty_name_rejected` — 422 on empty name
- [x] New test: `test_update_equipment_empty_name_rejected` — 422 on empty name
- [x] All existing equipment tests pass (17/17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)