### PR TITLE
feat(staff): add digital staff fields for AI agents

### DIFF
--- a/alembic/versions/d1e2f3a4b5c6_add_digital_staff_fields.py
+++ b/alembic/versions/d1e2f3a4b5c6_add_digital_staff_fields.py
@@ -1,0 +1,50 @@
+"""add digital staff fields to staff model
+
+Revision ID: d1e2f3a4b5c6
+Revises: 0c2125df7c3a
+Create Date: 2026-03-27 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d1e2f3a4b5c6"
+down_revision: Union[str, Sequence[str], None] = "0c2125df7c3a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "staff",
+        sa.Column(
+            "staff_type",
+            sqlmodel.sql.sqltypes.AutoString(length=20),
+            nullable=False,
+            server_default="human",
+        ),
+    )
+    op.add_column(
+        "staff",
+        sa.Column("agent_config", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "staff",
+        sa.Column(
+            "avatar_emoji",
+            sqlmodel.sql.sqltypes.AutoString(length=10),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("staff", "avatar_emoji")
+    op.drop_column("staff", "agent_config")
+    op.drop_column("staff", "staff_type")

--- a/scripts/seed_digital_staff.py
+++ b/scripts/seed_digital_staff.py
@@ -1,0 +1,70 @@
+"""Seed script for default AI staff members.
+
+Usage:
+    uv run python scripts/seed_digital_staff.py
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure src is on path when running from project root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+from sqlmodel import Session, select
+
+from lab_manager.config import get_settings
+from lab_manager.models.staff import Staff
+
+
+DIGITAL_STAFF = [
+    {
+        "name": "Lab Assistant",
+        "email": "lab-assistant@labclaw.local",
+        "role": "ai_agent",
+        "role_level": 1,
+        "staff_type": "ai_agent",
+        "avatar_emoji": "\U0001f916",
+        "agent_config": {
+            "role": "lab_assistant",
+            "capabilities": ["inventory", "documents", "search"],
+        },
+    },
+    {
+        "name": "Safety Officer",
+        "email": "safety-officer@labclaw.local",
+        "role": "ai_agent",
+        "role_level": 1,
+        "staff_type": "ai_agent",
+        "avatar_emoji": "\U0001f52c",
+        "agent_config": {
+            "role": "safety_officer",
+            "capabilities": ["safety", "compliance", "msds"],
+        },
+    },
+]
+
+
+def seed() -> None:
+    from sqlalchemy import create_engine
+
+    settings = get_settings()
+    engine = create_engine(settings.database_url)
+
+    with Session(engine) as session:
+        for data in DIGITAL_STAFF:
+            existing = session.exec(
+                select(Staff).where(Staff.email == data["email"])
+            ).first()
+            if existing:
+                print(f"  [skip] {data['name']} ({data['email']}) already exists")
+                continue
+            staff = Staff(**data)
+            session.add(staff)
+            print(f"  [add]  {data['name']} ({data['email']})")
+        session.commit()
+
+
+if __name__ == "__main__":
+    print("Seeding digital staff members ...")
+    seed()
+    print("Done.")

--- a/src/lab_manager/models/staff.py
+++ b/src/lab_manager/models/staff.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
+import sqlalchemy as sa
 from sqlmodel import Field
 
 from lab_manager.models.base import AuditMixin
@@ -25,3 +26,6 @@ class Staff(AuditMixin, table=True):
     access_expires_at: Optional[datetime] = Field(default=None)
     failed_login_count: int = Field(default=0)
     locked_until: Optional[datetime] = Field(default=None)
+    staff_type: str = Field(default="human", max_length=20)
+    agent_config: Optional[dict] = Field(default=None, sa_column=sa.Column(sa.JSON))
+    avatar_emoji: Optional[str] = Field(default=None, max_length=10)

--- a/tests/test_digital_staff.py
+++ b/tests/test_digital_staff.py
@@ -1,0 +1,77 @@
+"""Tests for digital staff fields (staff_type, agent_config, avatar_emoji)."""
+
+from sqlmodel import Session, SQLModel, create_engine, select
+
+from lab_manager.models.staff import Staff
+
+
+def _make_engine():
+    """In-memory SQLite engine for unit tests."""
+    engine = create_engine("sqlite://")
+    SQLModel.metadata.create_all(engine)
+    return engine
+
+
+def test_staff_type_defaults_to_human():
+    """New staff members default to staff_type='human'."""
+    engine = _make_engine()
+    with Session(engine) as session:
+        staff = Staff(name="Alice")
+        session.add(staff)
+        session.commit()
+        session.refresh(staff)
+        assert staff.staff_type == "human"
+
+
+def test_create_ai_agent_staff():
+    """Staff can be created with staff_type='ai_agent'."""
+    engine = _make_engine()
+    with Session(engine) as session:
+        staff = Staff(
+            name="LabBot",
+            email="labbot@labclaw.local",
+            staff_type="ai_agent",
+            avatar_emoji=":robot:",
+        )
+        session.add(staff)
+        session.commit()
+        session.refresh(staff)
+        assert staff.staff_type == "ai_agent"
+        assert staff.avatar_emoji == ":robot:"
+
+
+def test_agent_config_can_be_none():
+    """agent_config is optional and defaults to None."""
+    engine = _make_engine()
+    with Session(engine) as session:
+        staff = Staff(name="Bob", staff_type="human")
+        session.add(staff)
+        session.commit()
+        session.refresh(staff)
+        assert staff.agent_config is None
+
+
+def test_agent_config_stores_and_retrieves_json():
+    """agent_config stores a dict and retrieves it intact."""
+    engine = _make_engine()
+    with Session(engine) as session:
+        config = {
+            "role": "lab_assistant",
+            "capabilities": ["inventory", "documents", "search"],
+        }
+        staff = Staff(
+            name="Lab Assistant",
+            email="lab-asst@labclaw.local",
+            staff_type="ai_agent",
+            avatar_emoji=":test_tube:",
+            agent_config=config,
+        )
+        session.add(staff)
+        session.commit()
+
+        result = session.exec(
+            select(Staff).where(Staff.email == "lab-asst@labclaw.local")
+        ).one()
+        assert result.agent_config == config
+        assert result.agent_config["role"] == "lab_assistant"
+        assert "inventory" in result.agent_config["capabilities"]

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "lab-manager"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary
- Add `staff_type` field (default "human", supports "ai_agent")
- Add `agent_config` JSON field for AI agent configuration
- Add `avatar_emoji` for chat/display
- Alembic migration for new columns
- Seed script for 2 default AI staff members
- Tests for new fields

## Test plan
- [ ] Verify migration applies cleanly
- [ ] Verify staff defaults to staff_type="human"
- [ ] Verify agent_config stores/retrieves JSON
- [ ] Run `uv run pytest tests/test_digital_staff.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)