### PR TITLE
feat(feed): proactive AI feed page with alerts and activity

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -783,6 +783,7 @@ def create_app() -> FastAPI:
         email_ingest,
         equipment,
         export,
+        feed,
         import_routes,
         inventory,
         knowledge,
@@ -833,6 +834,7 @@ def create_app() -> FastAPI:
     api_router.include_router(audit.router, prefix="/api/v1/audit", tags=["audit"])
     api_router.include_router(safety.router, prefix="/api/v1/safety", tags=["safety"])
     api_router.include_router(alerts.router, prefix="/api/v1/alerts", tags=["alerts"])
+    api_router.include_router(feed.router, prefix="/api/v1/feed", tags=["feed"])
     api_router.include_router(
         notifications.router,
         prefix="/api/v1/notifications",

--- a/src/lab_manager/api/routes/feed.py
+++ b/src/lab_manager/api/routes/feed.py
@@ -1,0 +1,206 @@
+"""Proactive AI feed endpoint — combines alerts, activity, and AI suggestions."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from lab_manager.api.deps import get_db
+from lab_manager.models.alert import Alert
+from lab_manager.models.audit import AuditLog
+from lab_manager.services.alerts import check_all_alerts
+
+router = APIRouter()
+
+
+def _severity_to_priority(severity: str) -> str:
+    """Map alert severity to feed priority."""
+    return {"critical": "high", "warning": "medium", "info": "low"}.get(severity, "low")
+
+
+def _build_alert_items(db: Session) -> list[dict]:
+    """Convert active alerts into feed items."""
+    alerts = db.scalars(
+        select(Alert)
+        .where(Alert.is_resolved.is_(False))
+        .order_by(Alert.created_at.desc())
+        .limit(50)
+    ).all()
+
+    items = []
+    for a in alerts:
+        action_url = None
+        if a.entity_type == "inventory":
+            action_url = "#inventory"
+        elif a.entity_type == "document":
+            action_url = "#review"
+        elif a.entity_type == "order":
+            action_url = "#orders"
+        elif a.entity_type == "product":
+            action_url = "#inventory"
+
+        items.append(
+            {
+                "id": f"alert-{a.id}",
+                "type": "alert",
+                "priority": _severity_to_priority(a.severity),
+                "title": a.alert_type.replace("_", " ").title(),
+                "description": a.message,
+                "timestamp": a.created_at.isoformat() if a.created_at else None,
+                "action_url": action_url,
+                "is_read": a.is_acknowledged,
+            }
+        )
+    return items
+
+
+def _build_activity_items(db: Session) -> list[dict]:
+    """Convert recent audit log entries into feed items."""
+    entries = db.scalars(
+        select(AuditLog).order_by(AuditLog.timestamp.desc()).limit(50)
+    ).all()
+
+    items = []
+    for e in entries:
+        action_label = {
+            "create": "Created",
+            "update": "Updated",
+            "delete": "Deleted",
+        }.get(e.action, e.action.title())
+
+        action_url = None
+        if e.table_name == "documents":
+            action_url = "#documents"
+        elif e.table_name == "inventory_items":
+            action_url = "#inventory"
+        elif e.table_name == "orders":
+            action_url = "#orders"
+        elif e.table_name in ("vendors", "products"):
+            action_url = "#dashboard"
+
+        items.append(
+            {
+                "id": f"activity-{e.id}",
+                "type": "activity",
+                "priority": "low",
+                "title": f"{action_label} {e.table_name.replace('_', ' ')}",
+                "description": f"Record #{e.record_id} was {e.action}d"
+                + (f" by {e.changed_by}" if e.changed_by else ""),
+                "timestamp": e.timestamp.isoformat() if e.timestamp else None,
+                "action_url": action_url,
+                "is_read": True,
+            }
+        )
+    return items
+
+
+def _build_suggestion_items(db: Session) -> list[dict]:
+    """Generate AI-suggested actions from current alert state."""
+    alerts = check_all_alerts(db)
+    suggestions = []
+    seen: set[str] = set()
+
+    for a in alerts:
+        key = a["type"]
+        if key in seen:
+            continue
+        seen.add(key)
+
+        title = ""
+        description = ""
+        action_url = None
+
+        if key == "expired":
+            title = "Remove expired items"
+            description = "Some inventory items have expired. Consider disposing them."
+            action_url = "#inventory"
+        elif key == "expiring_soon":
+            title = "Review expiring items"
+            description = (
+                "Items are approaching their expiry date. Plan usage or reorder."
+            )
+            action_url = "#inventory"
+        elif key == "low_stock":
+            title = "Reorder low-stock items"
+            description = "Products are below minimum stock levels. Place orders soon."
+            action_url = "#orders"
+        elif key == "out_of_stock":
+            title = "Order out-of-stock products"
+            description = "Some products have zero inventory. Reorder immediately."
+            action_url = "#orders"
+        elif key == "pending_review":
+            title = "Review pending documents"
+            description = "Documents are awaiting your review and approval."
+            action_url = "#review"
+        elif key == "stale_orders":
+            title = "Follow up on stale orders"
+            description = "Some orders have been pending for over 30 days."
+            action_url = "#orders"
+
+        if title:
+            suggestions.append(
+                {
+                    "id": f"suggestion-{uuid.uuid4().hex[:12]}",
+                    "type": "suggestion",
+                    "priority": "high"
+                    if key in ("expired", "out_of_stock")
+                    else "medium",
+                    "title": title,
+                    "description": description,
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "action_url": action_url,
+                    "is_read": False,
+                }
+            )
+
+    return suggestions
+
+
+@router.get("/")
+def get_feed(
+    item_type: Optional[str] = Query(
+        None, description="Filter by type: alert, activity, suggestion"
+    ),
+    priority: Optional[str] = Query(
+        None, description="Filter by priority: high, medium, low"
+    ),
+    db: Session = Depends(get_db),
+):
+    """Return combined feed items from alerts, activity log, and AI suggestions."""
+    items: list[dict] = []
+    items.extend(_build_alert_items(db))
+    items.extend(_build_activity_items(db))
+    items.extend(_build_suggestion_items(db))
+
+    if item_type:
+        items = [i for i in items if i["type"] == item_type]
+    if priority:
+        items = [i for i in items if i["priority"] == priority]
+
+    items.sort(key=lambda i: i.get("timestamp") or "", reverse=True)
+
+    return {
+        "items": items,
+        "total": len(items),
+    }
+
+
+@router.post("/{item_id}/read")
+def mark_feed_item_read(item_id: str, db: Session = Depends(get_db)):
+    """Mark a feed item as read. For alert items, acknowledges the underlying alert."""
+    if item_id.startswith("alert-"):
+        try:
+            alert_id = int(item_id.split("-", 1)[1])
+        except (ValueError, IndexError):
+            return {"status": "ok"}
+        alert = db.get(Alert, alert_id)
+        if alert and not alert.is_acknowledged:
+            alert.is_acknowledged = True
+            alert.acknowledged_at = datetime.now(timezone.utc)
+            db.flush()
+    return {"status": "ok"}

--- a/src/lab_manager/static/index.html
+++ b/src/lab_manager/static/index.html
@@ -140,6 +140,12 @@ tailwind.config = {
         <span class="material-symbols-outlined text-xl">dashboard</span>
         Dashboard
       </a>
+      <a href="#feed" data-nav="feed"
+        class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors hover:bg-primary/5 text-slate-400">
+        <span class="material-symbols-outlined text-xl">notifications</span>
+        Feed
+        <span id="feed-count" class="hidden ml-auto min-w-[20px] h-5 flex items-center justify-center rounded-full bg-red-500 text-white text-[10px] font-bold px-1.5"></span>
+      </a>
       <a href="#documents" data-nav="documents"
         class="flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors hover:bg-primary/5 text-slate-400">
         <span class="material-symbols-outlined text-xl">description</span>
@@ -220,6 +226,27 @@ tailwind.config = {
             <div class="text-xs text-slate-500 uppercase tracking-wider font-medium mb-4">Document Types</div>
             <div id="type-chart"></div>
           </div>
+        </div>
+      </div>
+
+      <!-- ===== FEED VIEW ===== -->
+      <div id="view-feed" class="hidden">
+        <div class="flex items-center justify-between mb-4">
+          <div>
+            <h2 class="text-lg font-semibold text-white">Feed</h2>
+            <p class="text-sm text-slate-500">Alerts, activity, and AI-suggested actions</p>
+          </div>
+          <div class="flex gap-2">
+            <select id="feed-type-filter" onchange="loadFeed()" class="bg-surface-dark border border-border-dark rounded-lg px-3 py-1.5 text-sm text-slate-300">
+              <option value="">All types</option>
+              <option value="alert">Alerts</option>
+              <option value="activity">Activity</option>
+              <option value="suggestion">Suggestions</option>
+            </select>
+          </div>
+        </div>
+        <div class="bg-surface-dark border border-border-dark rounded-xl overflow-hidden">
+          <div id="feed-items"></div>
         </div>
       </div>
 
@@ -426,6 +453,7 @@ tailwind.config = {
 <!-- ==================== JS MODULES ==================== -->
 <script src="/static/js/api.js"></script>
 <script src="/static/js/dashboard.js"></script>
+<script src="/static/js/feed.js"></script>
 <script src="/static/js/documents.js"></script>
 <script src="/static/js/review.js"></script>
 <script src="/static/js/inventory.js"></script>

--- a/src/lab_manager/static/js/app.js
+++ b/src/lab_manager/static/js/app.js
@@ -2,6 +2,7 @@
 "use strict";
 
 const VIEWS = ["dashboard", "documents", "review", "inventory", "orders", "upload", "chat"];
+const VIEWS = ["dashboard", "feed", "documents", "review", "inventory", "orders", "upload"];
 
 // --- Setup wizard (first-run) ---
 async function handleSetup(e) {
@@ -133,6 +134,7 @@ function handleRoute() {
 
   // Load data for active view
   if (view === "dashboard") loadStats();
+  if (view === "feed") loadFeed();
   if (view === "documents") loadDocuments();
   if (view === "review") loadReviewQueue();
   if (view === "inventory") loadInventory();

--- a/src/lab_manager/static/js/feed.js
+++ b/src/lab_manager/static/js/feed.js
@@ -1,0 +1,146 @@
+// feed.js — Proactive AI feed page: alerts, activity, and suggestions
+"use strict";
+
+let feedRefreshTimer = null;
+
+const FEED_TYPE_ICONS = {
+  alert: "notifications_active",
+  activity: "history",
+  suggestion: "lightbulb",
+};
+
+const PRIORITY_STYLES = {
+  high: "bg-red-500/15 text-red-400 border-red-500/30",
+  medium: "bg-yellow-500/15 text-yellow-400 border-yellow-500/30",
+  low: "bg-slate-500/15 text-slate-400 border-slate-500/30",
+};
+
+const PRIORITY_LABELS = {
+  high: "High",
+  medium: "Medium",
+  low: "Low",
+};
+
+function _relativeDate(isoTs) {
+  if (!isoTs) return "Unknown";
+  const d = new Date(isoTs);
+  const now = new Date();
+  const diff = now - d;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "Just now";
+  if (mins < 60) return mins + "m ago";
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return hours + "h ago";
+  const days = Math.floor(hours / 24);
+  if (days === 1) return "Yesterday";
+  if (days < 7) return days + "d ago";
+  return d.toLocaleDateString();
+}
+
+function _dateGroup(isoTs) {
+  if (!isoTs) return "Older";
+  const d = new Date(isoTs);
+  const now = new Date();
+  const diff = now - d;
+  const days = Math.floor(diff / 86400000);
+  if (days < 1) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return "This Week";
+  return "Older";
+}
+
+function _renderFeedItem(item) {
+  const icon = FEED_TYPE_ICONS[item.type] || "info";
+  const priorityClass = PRIORITY_STYLES[item.priority] || PRIORITY_STYLES.low;
+  const priorityLabel = PRIORITY_LABELS[item.priority] || "Low";
+  const readClass = item.is_read ? "opacity-60" : "";
+  const relDate = _relativeDate(item.timestamp);
+
+  return `<div class="flex gap-3 p-4 border-b border-border-dark hover:bg-background-dark/30 transition-colors cursor-pointer ${readClass}" data-feed-id="${item.id}" onclick="markFeedRead('${item.id}')">
+    <div class="flex-shrink-0 w-9 h-9 rounded-lg bg-primary/10 flex items-center justify-center">
+      <span class="material-symbols-outlined text-primary text-lg">${icon}</span>
+    </div>
+    <div class="flex-1 min-w-0">
+      <div class="flex items-center gap-2 mb-1">
+        <span class="text-sm font-medium text-slate-200 truncate">${item.title}</span>
+        <span class="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold border ${priorityClass}">${priorityLabel}</span>
+      </div>
+      <p class="text-xs text-slate-400 line-clamp-2">${item.description}</p>
+    </div>
+    <div class="flex-shrink-0 text-right">
+      <span class="text-[11px] text-slate-500">${relDate}</span>
+      ${item.action_url ? `<div class="mt-1"><a href="${item.action_url}" class="text-[11px] text-primary hover:underline">View</a></div>` : ""}
+    </div>
+  </div>`;
+}
+
+function _renderFeedGroup(groupName, items) {
+  if (!items.length) return "";
+  return `<div class="mb-4">
+    <div class="px-4 py-2 text-xs font-semibold text-slate-500 uppercase tracking-wider bg-background-dark/50">${groupName}</div>
+    ${items.map(_renderFeedItem).join("")}
+  </div>`;
+}
+
+async function loadFeed() {
+  const container = document.getElementById("feed-items");
+  const countEl = document.getElementById("feed-count");
+  if (!container) return;
+
+  container.innerHTML = `<div class="flex items-center justify-center py-12 text-slate-500">
+    <span class="material-symbols-outlined animate-spin text-xl mr-2">progress_activity</span>Loading feed...
+  </div>`;
+
+  try {
+    const r = await fetch("/api/v1/feed/");
+    if (!r.ok) throw new Error("Failed to load feed");
+    const data = await r.json();
+    const items = data.items || [];
+
+    if (countEl) {
+      const unread = items.filter((i) => !i.is_read).length;
+      countEl.textContent = unread > 0 ? unread : "";
+      countEl.classList.toggle("hidden", unread === 0);
+    }
+
+    if (!items.length) {
+      container.innerHTML = `<div class="flex flex-col items-center justify-center py-16 text-slate-500">
+        <span class="material-symbols-outlined text-4xl mb-3">notifications_off</span>
+        <p class="text-sm">No feed items yet</p>
+        <p class="text-xs text-slate-600 mt-1">Alerts and activity will appear here</p>
+      </div>`;
+      return;
+    }
+
+    const groups = { Today: [], Yesterday: [], "This Week": [], Older: [] };
+    for (const item of items) {
+      const g = _dateGroup(item.timestamp);
+      if (groups[g]) groups[g].push(item);
+      else groups["Older"].push(item);
+    }
+
+    container.innerHTML =
+      _renderFeedGroup("Today", groups["Today"]) +
+      _renderFeedGroup("Yesterday", groups["Yesterday"]) +
+      _renderFeedGroup("This Week", groups["This Week"]) +
+      _renderFeedGroup("Older", groups["Older"]);
+  } catch (e) {
+    container.innerHTML = `<div class="flex items-center justify-center py-12 text-red-400 text-sm">Failed to load feed</div>`;
+  }
+
+  // Auto-refresh every 60 seconds
+  if (feedRefreshTimer) clearInterval(feedRefreshTimer);
+  feedRefreshTimer = setInterval(() => {
+    if (window.location.hash === "#feed") loadFeed();
+  }, 60000);
+}
+
+async function markFeedRead(itemId) {
+  // Optimistically mark as read in the UI
+  const el = document.querySelector(`[data-feed-id="${itemId}"]`);
+  if (el) el.classList.add("opacity-60");
+
+  try {
+    await fetch(`/api/v1/feed/${itemId}/read`, { method: "POST" });
+  } catch {}
+}

--- a/tests/test_feed_api.py
+++ b/tests/test_feed_api.py
@@ -1,0 +1,199 @@
+"""Test proactive feed API endpoint."""
+
+from datetime import date, timedelta
+
+from lab_manager.models.alert import Alert
+from lab_manager.models.inventory import InventoryItem
+from lab_manager.models.product import Product
+from lab_manager.models.vendor import Vendor
+
+
+def _seed_vendor(db):
+    v = Vendor(name="FeedTestVendor")
+    db.add(v)
+    db.commit()
+    db.refresh(v)
+    return v
+
+
+REQUIRED_FIELDS = {
+    "id",
+    "type",
+    "priority",
+    "title",
+    "description",
+    "timestamp",
+    "action_url",
+    "is_read",
+}
+
+
+def test_feed_returns_list(client):
+    """GET /api/v1/feed returns a valid response with items list."""
+    r = client.get("/api/v1/feed/")
+    assert r.status_code == 200
+    data = r.json()
+    assert "items" in data
+    assert "total" in data
+    assert isinstance(data["items"], list)
+    assert data["total"] == len(data["items"])
+
+
+def test_feed_items_have_required_fields(client, db_session):
+    """Every feed item must have all required fields."""
+    v = _seed_vendor(db_session)
+    p = Product(catalog_number="FT1", name="FeedTest Product", vendor_id=v.id)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+
+    item = InventoryItem(
+        product_id=p.id,
+        quantity_on_hand=5,
+        expiry_date=date.today() - timedelta(days=1),
+        status="available",
+    )
+    db_session.add(item)
+    db_session.commit()
+
+    alert = Alert(
+        alert_type="expired",
+        severity="critical",
+        message=f"Inventory item {item.id} expired",
+        entity_type="inventory",
+        entity_id=item.id,
+    )
+    db_session.add(alert)
+    db_session.commit()
+
+    r = client.get("/api/v1/feed/")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] >= 1
+    for feed_item in data["items"]:
+        missing = REQUIRED_FIELDS - set(feed_item.keys())
+        assert not missing, f"Feed item missing fields: {missing}"
+
+
+def test_feed_includes_alerts(client, db_session):
+    """Feed should include items from the alerts table."""
+    v = _seed_vendor(db_session)
+    p = Product(catalog_number="FT2", name="FeedTest Low Stock", vendor_id=v.id)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+
+    alert = Alert(
+        alert_type="low_stock",
+        severity="warning",
+        message="Product is low on stock",
+        entity_type="product",
+        entity_id=p.id,
+    )
+    db_session.add(alert)
+    db_session.commit()
+
+    r = client.get("/api/v1/feed/")
+    data = r.json()
+    alert_items = [i for i in data["items"] if i["type"] == "alert"]
+    assert len(alert_items) >= 1
+    assert alert_items[0]["priority"] in ("high", "medium", "low")
+
+
+def test_feed_filter_by_type(client, db_session):
+    """Filtering by type returns only matching items."""
+    v = _seed_vendor(db_session)
+    p = Product(catalog_number="FT3", name="FeedTest Filter", vendor_id=v.id)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+
+    alert = Alert(
+        alert_type="expiring_soon",
+        severity="warning",
+        message="Item expiring soon",
+        entity_type="inventory",
+        entity_id=p.id,
+    )
+    db_session.add(alert)
+    db_session.commit()
+
+    r = client.get("/api/v1/feed/", params={"item_type": "alert"})
+    assert r.status_code == 200
+    data = r.json()
+    for item in data["items"]:
+        assert item["type"] == "alert"
+
+
+def test_feed_filter_by_priority(client):
+    """Filtering by priority returns only matching items."""
+    r = client.get("/api/v1/feed/", params={"priority": "high"})
+    assert r.status_code == 200
+    data = r.json()
+    for item in data["items"]:
+        assert item["priority"] == "high"
+
+
+def test_mark_feed_item_read(client, db_session):
+    """POST /api/v1/feed/{id}/read marks alert as acknowledged."""
+    v = _seed_vendor(db_session)
+    p = Product(catalog_number="FT4", name="FeedTest Read", vendor_id=v.id)
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+
+    alert = Alert(
+        alert_type="low_stock",
+        severity="warning",
+        message="Low stock product",
+        entity_type="product",
+        entity_id=p.id,
+    )
+    db_session.add(alert)
+    db_session.commit()
+    db_session.refresh(alert)
+
+    r = client.post(f"/api/v1/feed/alert-{alert.id}/read")
+    assert r.status_code == 200
+
+    db_session.refresh(alert)
+    assert alert.is_acknowledged is True
+
+
+def test_feed_includes_suggestions(client, db_session):
+    """Feed should include AI-suggested actions based on alert conditions."""
+    v = _seed_vendor(db_session)
+    p = Product(
+        catalog_number="FT5",
+        name="FeedTest Suggestion",
+        vendor_id=v.id,
+        min_stock_level=10,
+    )
+    db_session.add(p)
+    db_session.commit()
+    db_session.refresh(p)
+
+    item = InventoryItem(
+        product_id=p.id,
+        quantity_on_hand=0,
+        status="available",
+    )
+    db_session.add(item)
+    db_session.commit()
+
+    r = client.get("/api/v1/feed/")
+    data = r.json()
+    suggestions = [i for i in data["items"] if i["type"] == "suggestion"]
+    assert len(suggestions) >= 1
+    assert suggestions[0]["title"]  # has a title
+    assert suggestions[0]["action_url"]  # has a navigation link
+
+
+def test_feed_priority_values(client):
+    """All feed items have valid priority values."""
+    r = client.get("/api/v1/feed/")
+    assert r.status_code == 200
+    data = r.json()
+    valid_priorities = {"high", "medium", "low"}
+    for item in data["items"]:
+        assert item["priority"] in valid_priorities


### PR DESCRIPTION
## Summary
- New `/api/v1/feed` endpoint combining alerts, activity, and AI suggestions
- Feed UI page in SPA with priority badges, date grouping, auto-refresh
- Sidebar navigation with bell icon and unread count badge
- Tests for feed API (8 tests covering list, fields, filters, mark-read, suggestions)

## Test plan
- [ ] Verify feed page loads in sidebar
- [ ] Verify feed API returns structured items
- [ ] Verify auto-refresh works
- [ ] Run `uv run pytest tests/test_feed_api.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)