### PR TITLE
feat(safety): add MSDS auto-linking and safety data for products

### DIFF
--- a/alembic/versions/c1d2e3f4a5b6_add_msds_fields_to_product.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_msds_fields_to_product.py
@@ -1,0 +1,54 @@
+"""add msds fields to product
+
+Revision ID: c1d2e3f4a5b6
+Revises: 0c2125df7c3a
+Create Date: 2026-03-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c1d2e3f4a5b6"
+down_revision: Union[str, Sequence[str]] = "0c2125df7c3a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "products",
+        sa.Column(
+            "hazard_class",
+            sqlmodel.sql.sqltypes.AutoString(length=100),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "products",
+        sa.Column(
+            "msds_url",
+            sqlmodel.sql.sqltypes.AutoString(length=500),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "products",
+        sa.Column(
+            "requires_safety_review",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("products", "requires_safety_review")
+    op.drop_column("products", "msds_url")
+    op.drop_column("products", "hazard_class")

--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -75,6 +75,9 @@ class ProductUpdate(BaseModel):
     storage_temp: Optional[str] = PydanticField(default=None, max_length=50)
     unit: Optional[str] = PydanticField(default=None, max_length=50)
     hazard_info: Optional[str] = PydanticField(default=None, max_length=255)
+    hazard_class: Optional[str] = PydanticField(default=None, max_length=100)
+    msds_url: Optional[str] = PydanticField(default=None, max_length=500)
+    requires_safety_review: Optional[bool] = None
     extra: Optional[dict] = None
 
     @field_validator("cas_number")
@@ -99,6 +102,9 @@ class ProductResponse(BaseModel):
     storage_temp: Optional[str] = None
     unit: Optional[str] = None
     hazard_info: Optional[str] = None
+    hazard_class: Optional[str] = None
+    msds_url: Optional[str] = None
+    requires_safety_review: bool = False
     extra: dict = {}
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -263,6 +269,67 @@ def enrich_product_endpoint(product_id: int, db: Session = Depends(get_db)):
     for enrich_key, model_field in field_map.items():
         if enrich_key in data and getattr(product, model_field) is None:
             setattr(product, model_field, data[enrich_key])
+
+    db.flush()
+    db.refresh(product)
+    index_product_record(product)
+    return product
+
+
+@router.get("/{product_id}/msds")
+def get_product_msds(product_id: int, db: Session = Depends(get_db)):
+    """Return MSDS/SDS info for a product. Auto-lookup if CAS exists."""
+    from lab_manager.services.msds import get_safety_alert, lookup_msds
+
+    product = get_or_404(db, Product, product_id, "Product")
+
+    result: dict = {
+        "product_id": product_id,
+        "name": product.name,
+        "cas_number": product.cas_number,
+        "msds_url": product.msds_url,
+        "hazard_class": product.hazard_class,
+        "requires_safety_review": product.requires_safety_review,
+        "signal_word": None,
+        "safety_alert": None,
+    }
+
+    # If CAS exists but no MSDS data yet, do an auto-lookup.
+    if product.cas_number and not product.msds_url:
+        msds_data = lookup_msds(product.cas_number)
+        result["msds_url"] = msds_data.get("msds_url")
+        result["hazard_class"] = msds_data.get("hazard_class")
+        result["signal_word"] = msds_data.get("signal_word")
+        result["requires_safety_review"] = msds_data.get(
+            "requires_safety_review", False
+        )
+
+    if result["hazard_class"]:
+        result["safety_alert"] = get_safety_alert(product.name, result["hazard_class"])
+
+    return result
+
+
+@router.post("/{product_id}/lookup-msds", response_model=ProductResponse)
+def lookup_product_msds(product_id: int, db: Session = Depends(get_db)):
+    """Trigger MSDS lookup and update product record with results."""
+    from lab_manager.services.msds import lookup_msds
+
+    product = get_or_404(db, Product, product_id, "Product")
+
+    if not product.cas_number:
+        from lab_manager.exceptions import ValidationError
+
+        raise ValidationError("Product has no CAS number -- cannot look up MSDS data")
+
+    msds_data = lookup_msds(product.cas_number)
+
+    if msds_data.get("msds_url") and not product.msds_url:
+        product.msds_url = msds_data["msds_url"]
+    if msds_data.get("hazard_class") and not product.hazard_class:
+        product.hazard_class = msds_data["hazard_class"]
+    if msds_data.get("requires_safety_review"):
+        product.requires_safety_review = True
 
     db.flush()
     db.refresh(product)

--- a/src/lab_manager/models/product.py
+++ b/src/lab_manager/models/product.py
@@ -62,6 +62,11 @@ class Product(AuditMixin, table=True):
     is_controlled: bool = Field(default=False)
     is_active: bool = Field(default=True)
 
+    # MSDS / safety data
+    hazard_class: Optional[str] = Field(default=None, max_length=100)
+    msds_url: Optional[str] = Field(default=None, max_length=500)
+    requires_safety_review: bool = Field(default=False)
+
     vendor: Optional["Vendor"] = Relationship(back_populates="products")
     order_items: List["OrderItem"] = Relationship(back_populates="product")
     inventory_items: List["InventoryItem"] = Relationship(back_populates="product")

--- a/src/lab_manager/services/msds.py
+++ b/src/lab_manager/services/msds.py
@@ -1,0 +1,274 @@
+"""MSDS / SDS auto-linking service via PubChem."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_PUBCHEM_COMPOUND_URL = (
+    "https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{query}/JSON"
+)
+_TIMEOUT = 5.0
+
+# GHS hazard pictogram keywords mapped to standard hazard classes.
+_HAZARD_KEYWORDS: dict[str, str] = {
+    "Flammable": "Flammable",
+    "Flam.": "Flammable",
+    "Pyrophoric": "Pyrophoric",
+    "Self-reactive": "Self-reactive",
+    "Self-heating": "Self-heating",
+    "Organic peroxide": "Organic Peroxide",
+    "Corrosive": "Corrosive",
+    "Corros.": "Corrosive",
+    "Skin Corrosion": "Corrosive",
+    "Eye Damage": "Eye Damage",
+    "Oxidizer": "Oxidizer",
+    "Oxid.": "Oxidizer",
+    "Gas under pressure": "Compressed Gas",
+    "Compressed Gas": "Compressed Gas",
+    "Liquefied gas": "Compressed Gas",
+    "Toxic": "Acute Toxicity",
+    "Acute Tox.": "Acute Toxicity",
+    "Fatal": "Acute Toxicity",
+    "Carcinogenic": "Carcinogenic",
+    "Carc.": "Carcinogenic",
+    "Mutagenic": "Mutagenic",
+    "Muta.": "Mutagenic",
+    "Reproductive": "Reproductive Toxicity",
+    "Repr.": "Reproductive Toxicity",
+    "STOT SE": "Specific Target Organ Toxicity (Single Exposure)",
+    "STOT RE": "Specific Target Organ Toxicity (Repeated Exposure)",
+    "Aspiration": "Aspiration Hazard",
+    "Aquatic Acute": "Environmental Hazard",
+    "Aquatic Chronic": "Environmental Hazard",
+}
+
+# Signal word mapping based on hazard severity.
+_SIGNAL_WORD_MAP: dict[str, str] = {
+    "Flammable": "Warning",
+    "Pyrophoric": "Danger",
+    "Self-reactive": "Danger",
+    "Self-heating": "Warning",
+    "Organic Peroxide": "Danger",
+    "Corrosive": "Danger",
+    "Eye Damage": "Danger",
+    "Oxidizer": "Danger",
+    "Compressed Gas": "Warning",
+    "Acute Toxicity": "Danger",
+    "Carcinogenic": "Danger",
+    "Mutagenic": "Danger",
+    "Reproductive Toxicity": "Danger",
+    "Specific Target Organ Toxicity (Single Exposure)": "Danger",
+    "Specific Target Organ Toxicity (Repeated Exposure)": "Danger",
+    "Aspiration Hazard": "Danger",
+    "Environmental Hazard": "Warning",
+}
+
+# Hazard classes that require safety review.
+_REVIEW_REQUIRED_CLASSES = {
+    "Pyrophoric",
+    "Self-reactive",
+    "Organic Peroxide",
+    "Corrosive",
+    "Acute Toxicity",
+    "Carcinogenic",
+    "Mutagenic",
+    "Reproductive Toxicity",
+    "Specific Target Organ Toxicity (Single Exposure)",
+    "Specific Target Organ Toxicity (Repeated Exposure)",
+    "Aspiration Hazard",
+}
+
+# Safety alert messages by hazard class.
+_SAFETY_ALERTS: dict[str, str] = {
+    "Flammable": (
+        "Flammable liquid -- use in fume hood, away from ignition sources. "
+        "Store in flammable cabinet."
+    ),
+    "Pyrophoric": (
+        "Pyrophoric substance -- ignites spontaneously in air. "
+        "Handle under inert atmosphere (N2/Ar). Fire extinguisher required."
+    ),
+    "Self-reactive": (
+        "Self-reactive substance -- may decompose explosively. "
+        "Keep away from heat, light, and incompatible materials."
+    ),
+    "Self-heating": (
+        "Self-heating substance -- may catch fire. Store in cool, well-ventilated area."
+    ),
+    "Organic Peroxide": (
+        "Organic peroxide -- may explode when heated. "
+        "Store at controlled temperature, away from metals and accelerators."
+    ),
+    "Corrosive": (
+        "Corrosive substance -- causes severe skin burns and eye damage. "
+        "Wear chemical-resistant gloves, goggles, and lab coat. Use in fume hood."
+    ),
+    "Eye Damage": (
+        "Causes serious eye damage. "
+        "Wear splash-proof goggles. Eye wash station must be accessible."
+    ),
+    "Oxidizer": (
+        "Oxidizing substance -- may cause or intensify fire. "
+        "Keep away from flammable and combustible materials."
+    ),
+    "Compressed Gas": (
+        "Compressed gas -- risk of explosion if heated. "
+        "Secure cylinder upright, use pressure regulator, ventilated area."
+    ),
+    "Acute Toxicity": (
+        "Acute toxic substance -- fatal if swallowed, inhaled, or absorbed. "
+        "Use in fume hood with full PPE. Do not taste or smell."
+    ),
+    "Carcinogenic": (
+        "Carcinogen -- may cause cancer. "
+        "Minimize exposure. Use glove box or fume hood. Full PPE required."
+    ),
+    "Mutagenic": (
+        "Mutagen -- may cause genetic damage. "
+        "Avoid skin contact and inhalation. Use in containment."
+    ),
+    "Reproductive Toxicity": (
+        "Reproductive toxicant -- may damage fertility or unborn child. "
+        "Inform supervisor if pregnant. Strict exposure control."
+    ),
+    "Specific Target Organ Toxicity (Single Exposure)": (
+        "STOT-SE -- may cause organ damage from single exposure. "
+        "Use in well-ventilated area. Know target organs."
+    ),
+    "Specific Target Organ Toxicity (Repeated Exposure)": (
+        "STOT-RE -- causes organ damage through prolonged exposure. "
+        "Monitor exposure, use PPE, schedule regular health checks."
+    ),
+    "Aspiration Hazard": (
+        "Aspiration hazard -- may be fatal if swallowed and enters airways. "
+        "Do NOT induce vomiting if swallowed. Seek immediate medical help."
+    ),
+    "Environmental Hazard": (
+        "Environmental hazard -- toxic to aquatic life. "
+        "Do not discharge into drains. Collect spills for proper disposal."
+    ),
+}
+
+
+def _extract_ghs_hazards(data: dict[str, Any]) -> list[str]:
+    """Extract GHS hazard classifications from PubChem JSON response."""
+    hazards: list[str] = []
+    sections = data.get("PC_Compounds", [{}])[0].get("props", [])
+    for prop in sections:
+        label = prop.get("urn", {}).get("label", "")
+        if "GHS" in label or "Hazard" in label:
+            value = prop.get("value", {})
+            sval = value.get("sval", "")
+            if sval:
+                hazards.append(sval)
+    return hazards
+
+
+def _classify_hazard(hazards: list[str]) -> tuple[str, str]:
+    """Classify GHS hazards into a hazard class and signal word.
+
+    Returns (hazard_class, signal_word). hazard_class is comma-separated
+    unique classes; signal_word is "Danger" if any mapped class maps to it.
+    """
+    found_classes: list[str] = []
+    signal_word = ""
+    for hazard_text in hazards:
+        for keyword, cls in _HAZARD_KEYWORDS.items():
+            if keyword in hazard_text and cls not in found_classes:
+                found_classes.append(cls)
+                if _SIGNAL_WORD_MAP.get(cls) == "Danger":
+                    signal_word = "Danger"
+    if not signal_word and found_classes:
+        signal_word = "Warning"
+    hazard_class = ", ".join(found_classes)
+    return hazard_class, signal_word
+
+
+def _build_msds_url(cid: int | None) -> str | None:
+    """Build a link to the PubChem compound page (acts as SDS landing page)."""
+    if cid is None:
+        return None
+    return f"https://pubchem.ncbi.nlm.nih.gov/compound/{cid}"
+
+
+def lookup_msds(cas_number: str) -> dict[str, Any]:
+    """Look up MSDS/SDS data for a compound by CAS number.
+
+    Returns dict with keys: msds_url, hazard_class, signal_word,
+    requires_safety_review. Returns empty-valued dict on failure.
+    """
+    result: dict[str, Any] = {
+        "msds_url": None,
+        "hazard_class": None,
+        "signal_word": None,
+        "requires_safety_review": False,
+    }
+    if not cas_number or not cas_number.strip():
+        return result
+    url = _PUBCHEM_COMPOUND_URL.format(query=cas_number.strip())
+    try:
+        resp = httpx.get(url, timeout=_TIMEOUT, follow_redirects=True)
+        if resp.status_code == 404:
+            logger.info("PubChem: no compound found for CAS %s", cas_number)
+            return result
+        if resp.status_code == 429:
+            logger.warning("PubChem rate limit exceeded for CAS %s", cas_number)
+            return result
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.TimeoutException:
+        logger.warning("PubChem timeout for CAS %s", cas_number)
+        return result
+    except httpx.HTTPStatusError as exc:
+        logger.warning(
+            "PubChem HTTP %s for CAS %s",
+            exc.response.status_code,
+            cas_number,
+        )
+        return result
+    except Exception:
+        logger.exception("Unexpected error looking up MSDS for CAS %s", cas_number)
+        return result
+
+    # Extract CID for the SDS URL.
+    cid_list = data.get("PC_Compounds", [])
+    cid = None
+    if cid_list:
+        cid = cid_list[0].get("id", {}).get("id", {}).get("cid")
+    result["msds_url"] = _build_msds_url(cid)
+
+    # Extract GHS hazard classifications.
+    hazards = _extract_ghs_hazards(data)
+    hazard_class, signal_word = _classify_hazard(hazards)
+    result["hazard_class"] = hazard_class or None
+    result["signal_word"] = signal_word or None
+    result["requires_safety_review"] = any(
+        cls in _REVIEW_REQUIRED_CLASSES
+        for cls in hazard_class.split(", ")
+        if hazard_class
+    )
+    return result
+
+
+def get_safety_alert(product_name: str, hazard_class: str) -> str:
+    """Return a safety reminder text based on hazard class.
+
+    If multiple classes are present (comma-separated), returns the most
+    severe alert. Falls back to a generic message for unknown classes.
+    """
+    if not hazard_class:
+        return f"No specific safety data available for {product_name}."
+    classes = [c.strip() for c in hazard_class.split(",")]
+    for cls in reversed(classes):
+        alert = _SAFETY_ALERTS.get(cls)
+        if alert:
+            return alert
+    return (
+        f"Hazard class '{hazard_class}' detected for {product_name}. "
+        "Consult the Safety Data Sheet and follow institutional protocols."
+    )

--- a/tests/test_msds.py
+++ b/tests/test_msds.py
@@ -1,0 +1,424 @@
+"""Tests for MSDS auto-linking service and API endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests
+# ---------------------------------------------------------------------------
+
+
+class TestMSDSService:
+    """Unit tests for lab_manager.services.msds."""
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_success(self, mock_get):
+        """Given a CAS number with GHS data, returns full MSDS info."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 702}},
+                    "props": [
+                        {
+                            "urn": {"label": "GHS Hazard Statement"},
+                            "value": {
+                                "sval": "H225: Highly Flammable liquid and vapour"
+                            },
+                        },
+                        {
+                            "urn": {"label": "GHS Precaution Statement"},
+                            "value": {"sval": "P210: Keep away from heat"},
+                        },
+                    ],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("64-17-5")
+
+        assert result["msds_url"] == "https://pubchem.ncbi.nlm.nih.gov/compound/702"
+        assert result["hazard_class"] == "Flammable"
+        assert result["signal_word"] == "Warning"
+        assert result["requires_safety_review"] is False
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_dangerous_chemical(self, mock_get):
+        """Dangerous chemicals require safety review."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 750}},
+                    "props": [
+                        {
+                            "urn": {"label": "GHS Hazard Statement"},
+                            "value": {"sval": "H301: Toxic if swallowed"},
+                        },
+                    ],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("67-64-1")
+
+        assert result["requires_safety_review"] is True
+        assert result["signal_word"] == "Danger"
+        assert "Acute Toxicity" in result["hazard_class"]
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_not_found(self, mock_get):
+        """Given an unknown CAS, returns empty-valued result."""
+        response = MagicMock()
+        response.status_code = 404
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("00-00-0")
+
+        assert result["msds_url"] is None
+        assert result["hazard_class"] is None
+        assert result["signal_word"] is None
+        assert result["requires_safety_review"] is False
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_timeout(self, mock_get):
+        """Given a timeout, returns empty-valued result."""
+        mock_get.side_effect = httpx.TimeoutException("Timeout")
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("64-17-5")
+
+        assert result["msds_url"] is None
+
+    def test_lookup_msds_empty_cas(self):
+        """Empty CAS number returns empty-valued result without HTTP call."""
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("")
+        assert result["msds_url"] is None
+        assert result["hazard_class"] is None
+
+    def test_lookup_msds_none_cas(self):
+        """None CAS number returns empty-valued result."""
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds(None)  # type: ignore[arg-type]
+        assert result["msds_url"] is None
+
+    def test_safety_alert_flammable(self):
+        """Flammable hazard returns correct safety alert."""
+        from lab_manager.services.msds import get_safety_alert
+
+        alert = get_safety_alert("Ethanol", "Flammable")
+        assert "fume hood" in alert
+        assert "ignition" in alert.lower()
+
+    def test_safety_alert_corrosive(self):
+        """Corrosive hazard returns correct safety alert."""
+        from lab_manager.services.msds import get_safety_alert
+
+        alert = get_safety_alert("HCl", "Corrosive")
+        assert "gloves" in alert.lower()
+        assert "goggles" in alert.lower()
+
+    def test_safety_alert_unknown_class(self):
+        """Unknown hazard class returns generic safety message."""
+        from lab_manager.services.msds import get_safety_alert
+
+        alert = get_safety_alert("CustomChem", "CustomHazardType")
+        assert "CustomChem" in alert
+        assert "Safety Data Sheet" in alert
+
+    def test_safety_alert_empty_class(self):
+        """Empty hazard class returns no-safety-data message."""
+        from lab_manager.services.msds import get_safety_alert
+
+        alert = get_safety_alert("Water", "")
+        assert "No specific safety data" in alert
+
+    def test_safety_alert_multiple_classes(self):
+        """Multiple hazard classes returns the most severe alert."""
+        from lab_manager.services.msds import get_safety_alert
+
+        alert = get_safety_alert("TestChem", "Flammable, Corrosive")
+        # Corrosive is last/more severe, should be returned
+        assert "Corrosive" in alert or "gloves" in alert.lower()
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_rate_limit(self, mock_get):
+        """429 response returns empty-valued result."""
+        response = MagicMock()
+        response.status_code = 429
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("64-17-5")
+        assert result["msds_url"] is None
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_multiple_hazards(self, mock_get):
+        """Multiple GHS hazards are combined into comma-separated classes."""
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 702}},
+                    "props": [
+                        {
+                            "urn": {"label": "GHS Hazard Statement"},
+                            "value": {"sval": "H225: Highly Flammable liquid"},
+                        },
+                        {
+                            "urn": {"label": "GHS Hazard Classification"},
+                            "value": {"sval": "Acute Tox. 4"},
+                        },
+                    ],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("64-17-5")
+
+        assert "Flammable" in result["hazard_class"]
+        assert "Acute Toxicity" in result["hazard_class"]
+        assert result["signal_word"] == "Danger"
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_server_error(self, mock_get):
+        """500 server error returns empty-valued result."""
+        response = MagicMock()
+        response.status_code = 500
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Server Error", request=MagicMock(), response=response
+        )
+        mock_get.return_value = response
+
+        from lab_manager.services.msds import lookup_msds
+
+        result = lookup_msds("64-17-5")
+        assert result["msds_url"] is None
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestMSDSEndpoints:
+    """Integration tests for /api/v1/products/{id}/msds and /lookup-msds."""
+
+    def _create_product(self, client, name="Ethanol", cas_number="64-17-5"):
+        resp = client.post(
+            "/api/v1/products/",
+            json={
+                "name": name,
+                "catalog_number": "E7023",
+                "cas_number": cas_number,
+            },
+        )
+        assert resp.status_code == 201
+        return resp.json()
+
+    def _create_product_no_cas(self, client, name="Unknown Chem"):
+        resp = client.post(
+            "/api/v1/products/",
+            json={"name": name, "catalog_number": "UC001"},
+        )
+        assert resp.status_code == 201
+        return resp.json()
+
+    def test_product_response_includes_msds_fields(self, client):
+        """Product response includes MSDS fields."""
+        product = self._create_product(client)
+        resp = client.get(f"/api/v1/products/{product['id']}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "hazard_class" in data
+        assert "msds_url" in data
+        assert "requires_safety_review" in data
+
+    def test_msds_endpoint_no_cas(self, client):
+        """GET /msds for product without CAS returns defaults."""
+        product = self._create_product_no_cas(client)
+        resp = client.get(f"/api/v1/products/{product['id']}/msds")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cas_number"] is None
+        assert data["msds_url"] is None
+        assert data["hazard_class"] is None
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_msds_endpoint_auto_lookup(self, mock_get, client):
+        """GET /msds auto-looks up when CAS exists but no MSDS data."""
+        product = self._create_product(client)
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 702}},
+                    "props": [
+                        {
+                            "urn": {"label": "GHS Hazard Statement"},
+                            "value": {"sval": "H225: Highly Flammable liquid"},
+                        },
+                    ],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        resp = client.get(f"/api/v1/products/{product['id']}/msds")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["msds_url"] == "https://pubchem.ncbi.nlm.nih.gov/compound/702"
+        assert data["hazard_class"] == "Flammable"
+        assert data["safety_alert"] is not None
+        assert "fume hood" in data["safety_alert"]
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_endpoint_persists(self, mock_get, client):
+        """POST /lookup-msds persists MSDS data to product record."""
+        product = self._create_product(client)
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 702}},
+                    "props": [
+                        {
+                            "urn": {"label": "GHS Hazard Statement"},
+                            "value": {"sval": "H225: Highly Flammable liquid"},
+                        },
+                    ],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        resp = client.post(f"/api/v1/products/{product['id']}/lookup-msds")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["msds_url"] == "https://pubchem.ncbi.nlm.nih.gov/compound/702"
+        assert data["hazard_class"] == "Flammable"
+
+        # Verify persistence
+        resp2 = client.get(f"/api/v1/products/{product['id']}")
+        assert resp2.status_code == 200
+        data2 = resp2.json()
+        assert data2["msds_url"] == "https://pubchem.ncbi.nlm.nih.gov/compound/702"
+
+    def test_lookup_msds_endpoint_no_cas_fails(self, client):
+        """POST /lookup-msds for product without CAS returns 422."""
+        product = self._create_product_no_cas(client)
+        resp = client.post(f"/api/v1/products/{product['id']}/lookup-msds")
+        assert resp.status_code == 422
+
+    def test_msds_endpoint_product_not_found(self, client):
+        """GET /products/99999/msds returns 404."""
+        resp = client.get("/api/v1/products/99999/msds")
+        assert resp.status_code == 404
+
+    def test_lookup_msds_endpoint_product_not_found(self, client):
+        """POST /products/99999/lookup-msds returns 404."""
+        resp = client.post("/api/v1/products/99999/lookup-msds")
+        assert resp.status_code == 404
+
+    @patch("lab_manager.services.msds.httpx.get")
+    def test_lookup_msds_does_not_overwrite_existing(self, mock_get, client):
+        """POST /lookup-msds preserves manually-set msds_url."""
+        product = self._create_product(client)
+
+        # Manually set msds_url first
+        client.patch(
+            f"/api/v1/products/{product['id']}",
+            json={"msds_url": "https://example.com/manual-sds.pdf"},
+        )
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "PC_Compounds": [
+                {
+                    "id": {"id": {"cid": 702}},
+                    "props": [],
+                }
+            ]
+        }
+        response.raise_for_status = MagicMock()
+        mock_get.return_value = response
+
+        resp = client.post(f"/api/v1/products/{product['id']}/lookup-msds")
+        assert resp.status_code == 200
+        data = resp.json()
+        # Should keep the manually-set URL
+        assert data["msds_url"] == "https://example.com/manual-sds.pdf"
+
+    def test_cas_number_stores_correctly(self, client):
+        """CAS number field stores and retrieves correctly."""
+        resp = client.post(
+            "/api/v1/products/",
+            json={
+                "name": "Acetone",
+                "catalog_number": "ACE001",
+                "cas_number": "67-64-1",
+            },
+        )
+        assert resp.status_code == 201
+        product = resp.json()
+        assert product["cas_number"] == "67-64-1"
+
+        # Retrieve to confirm persistence
+        resp2 = client.get(f"/api/v1/products/{product['id']}")
+        assert resp2.status_code == 200
+        assert resp2.json()["cas_number"] == "67-64-1"
+
+    def test_product_create_with_msds_fields(self, client):
+        """Product can be created with MSDS fields via PATCH."""
+        resp = client.post(
+            "/api/v1/products/",
+            json={"name": "TestChem", "catalog_number": "TC001"},
+        )
+        assert resp.status_code == 201
+        product = resp.json()
+
+        # Patch MSDS fields
+        resp2 = client.patch(
+            f"/api/v1/products/{product['id']}",
+            json={
+                "hazard_class": "Flammable, Corrosive",
+                "requires_safety_review": True,
+            },
+        )
+        assert resp2.status_code == 200
+        data = resp2.json()
+        assert data["hazard_class"] == "Flammable, Corrosive"
+        assert data["requires_safety_review"] is True


### PR DESCRIPTION
## Summary

- Add `hazard_class`, `msds_url`, and `requires_safety_review` fields to the Product model
- Create MSDS lookup service (`src/lab_manager/services/msds.py`) that queries PubChem REST API by CAS number to extract GHS hazard classifications and generate safety alerts
- Add `GET /api/v1/products/{id}/msds` endpoint (auto-lookup if CAS exists but no MSDS data)
- Add `POST /api/v1/products/{id}/lookup-msds` endpoint (persist MSDS data to product record)
- Include Alembic migration for the 3 new columns
- Follow existing patterns: PubChem service style, route structure, test patterns, error handling

## Files Changed

- `src/lab_manager/models/product.py` -- 3 new fields (hazard_class, msds_url, requires_safety_review)
- `src/lab_manager/services/msds.py` -- New service: lookup_msds(), get_safety_alert(), GHS hazard classification
- `src/lab_manager/api/routes/products.py` -- 2 new endpoints + updated schemas (ProductUpdate, ProductResponse)
- `alembic/versions/c1d2e3f4a5b6_add_msds_fields_to_product.py` -- Migration
- `tests/test_msds.py` -- 24 tests (14 service, 10 API endpoint)

## Test plan

- [x] 24 new tests all pass (service unit tests with mocked PubChem, API integration tests)
- [x] Existing test suite (54 related tests: test_pubchem, test_api_crud, test_models) all pass
- [x] Ruff lint clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)