### PR TITLE
fix(inventory): use custom ValidationError for 422 instead of pydantic's 500

### DIFF
--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -7,12 +7,13 @@ from decimal import Decimal
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select
 from sqlalchemy.orm import Session, selectinload
 
 from lab_manager.api.auth import require_permission
 from lab_manager.api.deps import get_db, get_or_404
+from lab_manager.exceptions import ValidationError
 from lab_manager.api.pagination import apply_sort, ilike_col, paginate
 from lab_manager.models.inventory import InventoryItem, InventoryStatus
 from lab_manager.models.product import Product

--- a/tests/test_api_crud.py
+++ b/tests/test_api_crud.py
@@ -361,6 +361,18 @@ def test_inventory_soft_delete(client):
     assert resp.json()["status"] == "deleted"
 
 
+def test_update_deleted_inventory_returns_422(client):
+    pid = _make_product(client, "UPD-DEL-INV")
+    resp = client.post(
+        "/api/v1/inventory/",
+        json={"product_id": pid, "quantity_on_hand": 5, "status": "available"},
+    )
+    iid = resp.json()["id"]
+    client.delete(f"/api/v1/inventory/{iid}")
+    resp = client.patch(f"/api/v1/inventory/{iid}", json={"quantity_on_hand": 10})
+    assert resp.status_code == 422
+
+
 def test_inventory_list_filters(client):
     pr = client.post(
         "/api/v1/products/", json={"catalog_number": "FP1", "name": "FilterProd"}


### PR DESCRIPTION
## Summary
- `update_inventory_item` imported `ValidationError` from `pydantic` instead of `lab_manager.exceptions`
- Raising pydantic's `ValidationError` produces HTTP 500 instead of the intended HTTP 422
- Users attempting to modify deleted/disposed/depleted inventory items got a confusing server error
- Changed import to use `lab_manager.exceptions.ValidationError` which maps to 422

## Test plan
- [x] New test: `test_update_deleted_inventory_returns_422` — verifies 422 response
- [x] Existing `test_inventory_soft_delete` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)