### PR TITLE
feat(safety): PPE requirements and waste disposal guidance based on GHS hazards

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -788,6 +788,7 @@ def create_app() -> FastAPI:
         order_requests,
         orders,
         products,
+        safety,
         search,
         telemetry,
         vendors,
@@ -828,6 +829,7 @@ def create_app() -> FastAPI:
         import_routes.router, prefix="/api/v1/import", tags=["import"]
     )
     api_router.include_router(audit.router, prefix="/api/v1/audit", tags=["audit"])
+    api_router.include_router(safety.router, prefix="/api/v1/safety", tags=["safety"])
     api_router.include_router(alerts.router, prefix="/api/v1/alerts", tags=["alerts"])
     api_router.include_router(
         notifications.router,

--- a/src/lab_manager/api/routes/inventory.py
+++ b/src/lab_manager/api/routes/inventory.py
@@ -294,7 +294,20 @@ def item_history(item_id: int, db: Session = Depends(get_db)):
     "/{item_id}/consume", dependencies=[Depends(require_permission("log_consumption"))]
 )
 def consume_item(item_id: int, body: ConsumeBody, db: Session = Depends(get_db)):
-    return inv_svc.consume(item_id, body.quantity, body.consumed_by, body.purpose, db)
+    item = inv_svc.consume(item_id, body.quantity, body.consumed_by, body.purpose, db)
+    result = {
+        "id": item.id,
+        "product_id": item.product_id,
+        "quantity_on_hand": float(item.quantity_on_hand),
+        "status": item.status,
+    }
+    # Attach safety reminder for hazardous products
+    product = getattr(item, "product", None)
+    if product and getattr(product, "is_hazardous", False):
+        from lab_manager.services.safety import get_product_safety_info
+
+        result["safety_reminder"] = get_product_safety_info(product)
+    return result
 
 
 @router.post(

--- a/src/lab_manager/api/routes/safety.py
+++ b/src/lab_manager/api/routes/safety.py
@@ -1,0 +1,39 @@
+"""Safety endpoints — PPE requirements and inventory safety scanning."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from lab_manager.api.deps import get_db, get_or_404
+from lab_manager.models.product import Product
+from lab_manager.services.safety import (
+    get_product_safety_info,
+    get_waste_disposal_guide,
+)
+
+router = APIRouter()
+
+
+@router.get("/ppe/{product_id}")
+def get_product_ppe(product_id: int, db: Session = Depends(get_db)):
+    """Return PPE requirements for a product based on its hazard codes."""
+    product = get_or_404(db, Product, product_id, "Product")
+    return get_product_safety_info(product)
+
+
+@router.get("/disposal/{hazard_code}")
+def get_disposal_guide(hazard_code: str):
+    """Return waste disposal instructions for a GHS hazard code."""
+    return {
+        "hazard_code": hazard_code.upper(),
+        "disposal_guide": get_waste_disposal_guide(hazard_code),
+    }
+
+
+@router.get("/inventory-scan")
+def inventory_safety_scan(db: Session = Depends(get_db)):
+    """Scan inventory for hazardous items without proper safety data."""
+    from lab_manager.services.safety import check_inventory_safety
+
+    return {"warnings": check_inventory_safety(db)}

--- a/src/lab_manager/services/safety.py
+++ b/src/lab_manager/services/safety.py
@@ -1,0 +1,445 @@
+"""Safety service — PPE requirements and waste disposal based on GHS hazard codes."""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from lab_manager.models.product import Product
+
+
+# ---------------------------------------------------------------------------
+# GHS Hazard Statement → PPE / disposal mapping
+# ---------------------------------------------------------------------------
+
+GHS_HAZARD_MAP: dict[str, dict[str, str]] = {
+    "H200": {
+        "category": "explosive",
+        "ppe": "Use in fume hood, no open flames, fire-resistant lab coat",
+        "disposal": "Collect explosive waste separately. Contact EHS for pickup.",
+    },
+    "H220": {
+        "category": "flammable_gas",
+        "ppe": "Use in fume hood, no open flames, fire-resistant lab coat",
+        "disposal": "Ventilate area. Do not dispose in sealed containers.",
+    },
+    "H225": {
+        "category": "highly_flammable",
+        "ppe": "Use in fume hood, no open flames, fire-resistant lab coat, safety goggles",
+        "disposal": "Collect in approved flammable waste container. Keep away from ignition.",
+    },
+    "H226": {
+        "category": "flammable",
+        "ppe": "Use in fume hood, no open flames, fire-resistant lab coat",
+        "disposal": "Collect in approved flammable waste container.",
+    },
+    "H228": {
+        "category": "flammable_solid",
+        "ppe": "No open flames, fire-resistant lab coat, safety goggles",
+        "disposal": "Collect in non-combustible waste container.",
+    },
+    "H240": {
+        "category": "explosive_self_reacting",
+        "ppe": "Use blast shield, face shield, fire-resistant lab coat",
+        "disposal": "Contact EHS immediately. Do not accumulate.",
+    },
+    "H241": {
+        "category": "self_reacting_explosive",
+        "ppe": "Use blast shield, face shield, fire-resistant lab coat",
+        "disposal": "Contact EHS immediately. Do not accumulate.",
+    },
+    "H250": {
+        "category": "pyrophoric",
+        "ppe": "Use under inert atmosphere, fire-resistant lab coat, face shield",
+        "disposal": "Quench under controlled conditions. Collect in inert waste.",
+    },
+    "H260": {
+        "category": "water_reactive",
+        "ppe": "Keep away from water, use in dry environment, face shield",
+        "disposal": "Quench slowly with appropriate reagent. Contact EHS.",
+    },
+    "H270": {
+        "category": "oxidizing_gas",
+        "ppe": "No flammable materials nearby, use in well-ventilated area",
+        "disposal": "Ventilate to atmosphere if safe. Follow institutional gas disposal.",
+    },
+    "H271": {
+        "category": "oxidizer",
+        "ppe": "No flammable materials nearby, safety goggles, lab coat",
+        "disposal": "Collect separately from flammable waste.",
+    },
+    "H272": {
+        "category": "oxidizing_solid",
+        "ppe": "No flammable materials nearby, safety goggles, lab coat",
+        "disposal": "Collect separately from flammable waste.",
+    },
+    "H280": {
+        "category": "compressed_gas",
+        "ppe": "Secure cylinder, use pressure regulator, safety goggles",
+        "disposal": "Return to supplier or vent per institutional protocol.",
+    },
+    "H290": {
+        "category": "corrosive_to_metals",
+        "ppe": "Corrosion-resistant gloves, safety goggles, lab coat",
+        "disposal": "Neutralize before disposal. Collect in compatible container.",
+    },
+    "H300": {
+        "category": "fatal_if_swallowed",
+        "ppe": "Use in fume hood, double gloves, face shield required, chemical apron",
+        "disposal": "Collect as hazardous chemical waste. Label clearly.",
+    },
+    "H301": {
+        "category": "toxic_if_swallowed",
+        "ppe": "Use in fume hood, double gloves, face shield required",
+        "disposal": "Collect as hazardous chemical waste. Label clearly.",
+    },
+    "H302": {
+        "category": "harmful_if_swallowed",
+        "ppe": "Wear nitrile gloves, safety goggles, lab coat",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H304": {
+        "category": "fatal_if_aspirated",
+        "ppe": "Do not swallow, wear nitrile gloves, safety goggles",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H310": {
+        "category": "fatal_in_contact_with_skin",
+        "ppe": "Double nitrile gloves, full-body protection, face shield",
+        "disposal": "Collect as hazardous chemical waste. Decontaminate surfaces.",
+    },
+    "H311": {
+        "category": "toxic_in_contact_with_skin",
+        "ppe": "Use in fume hood, double gloves, face shield required",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H312": {
+        "category": "harmful_in_contact_with_skin",
+        "ppe": "Wear nitrile gloves, lab coat",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H314": {
+        "category": "skin_corrosion",
+        "ppe": "Acid-resistant gloves, face shield, chemical apron",
+        "disposal": "Neutralize before disposal. Collect in compatible container.",
+    },
+    "H315": {
+        "category": "skin_irritation",
+        "ppe": "Wear nitrile gloves, lab coat",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H317": {
+        "category": "skin_sensitization",
+        "ppe": "Wear nitrile gloves, lab coat, avoid skin contact",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H318": {
+        "category": "eye_damage",
+        "ppe": "Safety goggles, face shield recommended",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H319": {
+        "category": "eye_irritation",
+        "ppe": "Safety goggles, lab coat",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H330": {
+        "category": "fatal_if_inhaled",
+        "ppe": "Use only in well-ventilated area or fume hood, respiratory protection",
+        "disposal": "Seal container. Collect as hazardous chemical waste.",
+    },
+    "H331": {
+        "category": "toxic_if_inhaled",
+        "ppe": "Use only in well-ventilated area or fume hood",
+        "disposal": "Seal container. Collect as hazardous chemical waste.",
+    },
+    "H332": {
+        "category": "harmful_if_inhaled",
+        "ppe": "Use in well-ventilated area",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H334": {
+        "category": "respiratory_sensitization",
+        "ppe": "Respiratory protection, use in fume hood",
+        "disposal": "Seal container. Collect as hazardous chemical waste.",
+    },
+    "H335": {
+        "category": "respiratory_irritation",
+        "ppe": "Use in fume hood or well-ventilated area",
+        "disposal": "Seal container. Collect as chemical waste.",
+    },
+    "H336": {
+        "category": "drowsiness",
+        "ppe": "Use in well-ventilated area, avoid prolonged exposure",
+        "disposal": "Collect as chemical waste.",
+    },
+    "H340": {
+        "category": "mutagenic",
+        "ppe": "Use in fume hood, double gloves, face shield, chemical apron",
+        "disposal": "Collect as hazardous chemical waste. Label as mutagen.",
+    },
+    "H341": {
+        "category": "suspected_mutagenic",
+        "ppe": "Use in fume hood, nitrile gloves, safety goggles, lab coat",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H350": {
+        "category": "carcinogenic",
+        "ppe": "Use in fume hood, double gloves, face shield, chemical apron",
+        "disposal": "Collect as hazardous chemical waste. Label as carcinogen.",
+    },
+    "H351": {
+        "category": "suspected_carcinogenic",
+        "ppe": "Use in fume hood, nitrile gloves, safety goggles, lab coat",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H360": {
+        "category": "reproductive_toxicity",
+        "ppe": "Use in fume hood, double gloves, face shield, chemical apron",
+        "disposal": "Collect as hazardous chemical waste. Label as reproductive toxin.",
+    },
+    "H361": {
+        "category": "suspected_reproductive_toxicity",
+        "ppe": "Use in fume hood, nitrile gloves, safety goggles, lab coat",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H370": {
+        "category": "organ_damage_single",
+        "ppe": "Use in fume hood, double gloves, face shield",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H371": {
+        "category": "organ_damage_single_suspected",
+        "ppe": "Use in fume hood, nitrile gloves, safety goggles",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H372": {
+        "category": "organ_damage_repeated",
+        "ppe": "Use in fume hood, double gloves, face shield",
+        "disposal": "Collect as hazardous chemical waste. Minimize exposure.",
+    },
+    "H373": {
+        "category": "organ_damage_repeated_suspected",
+        "ppe": "Use in fume hood, nitrile gloves, safety goggles",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+    "H400": {
+        "category": "aquatic_acute",
+        "ppe": "Wear nitrile gloves, safety goggles, lab coat",
+        "disposal": "Prevent release to drains, collect waste separately.",
+    },
+    "H401": {
+        "category": "aquatic_chronic_1",
+        "ppe": "Wear nitrile gloves, safety goggles, lab coat",
+        "disposal": "Prevent release to drains, collect waste separately.",
+    },
+    "H410": {
+        "category": "aquatic_chronic_1_lte",
+        "ppe": "Wear nitrile gloves, safety goggles, lab coat",
+        "disposal": "Prevent release to drains, collect waste separately.",
+    },
+    "H411": {
+        "category": "aquatic_chronic_2",
+        "ppe": "Wear nitrile gloves, safety goggles, lab coat",
+        "disposal": "Prevent release to drains, collect waste separately.",
+    },
+    "H412": {
+        "category": "aquatic_chronic_3",
+        "ppe": "Wear nitrile gloves, lab coat",
+        "disposal": "Avoid release to drains. Collect waste separately.",
+    },
+    "H413": {
+        "category": "aquatic_chronic_4",
+        "ppe": "Wear nitrile gloves, lab coat",
+        "disposal": "Avoid release to drains. Collect waste separately.",
+    },
+    "EUH071": {
+        "category": "corrosive_respiratory",
+        "ppe": "Use in fume hood, respiratory protection, face shield",
+        "disposal": "Collect as hazardous chemical waste.",
+    },
+}
+
+_HAZARD_RE = re.compile(r"\b(H\d{3}|EUH\d{3})\b", re.IGNORECASE)
+
+
+def _parse_hazard_codes(hazard_info: str) -> list[str]:
+    """Extract GHS hazard codes from free-text hazard_info field."""
+    if not hazard_info:
+        return []
+    return [m.upper() for m in _HAZARD_RE.findall(hazard_info)]
+
+
+def get_ppe_requirements(hazard_class: str) -> list[str]:
+    """Return PPE items needed for a single GHS hazard code.
+
+    Parameters
+    ----------
+    hazard_class:
+        A GHS hazard statement code (e.g. ``"H225"``, ``"H314"``).
+
+    Returns
+    -------
+    list[str]
+        Individual PPE items extracted from the mapped guidance string.
+    """
+    code = hazard_class.upper().strip()
+    entry = GHS_HAZARD_MAP.get(code)
+    if entry is None:
+        return ["Consult SDS for detailed PPE requirements"]
+    return [item.strip() for item in entry["ppe"].split(",")]
+
+
+def get_waste_disposal_guide(hazard_class: str) -> str:
+    """Return waste disposal instructions for a single GHS hazard code.
+
+    Parameters
+    ----------
+    hazard_class:
+        A GHS hazard statement code (e.g. ``"H400"``).
+
+    Returns
+    -------
+    str
+        Disposal guidance string.
+    """
+    code = hazard_class.upper().strip()
+    entry = GHS_HAZARD_MAP.get(code)
+    if entry is None:
+        return "Follow institutional chemical waste disposal procedures."
+    return entry["disposal"]
+
+
+def get_product_safety_info(product: Product) -> dict:
+    """Return full safety information for a product based on its hazard_info.
+
+    Parameters
+    ----------
+    product:
+        A Product model instance with ``hazard_info`` and ``is_hazardous`` fields.
+
+    Returns
+    -------
+    dict
+        Keys: ``product_id``, ``product_name``, ``is_hazardous``, ``hazard_codes``,
+        ``ppe_requirements``, ``waste_disposal``.
+    """
+    hazard_codes = _parse_hazard_codes(getattr(product, "hazard_info", "") or "")
+
+    ppe: list[str] = []
+    disposal: list[str] = []
+    for code in hazard_codes:
+        ppe.extend(get_ppe_requirements(code))
+        disposal.append(get_waste_disposal_guide(code))
+
+    # Deduplicate while preserving order
+    seen_ppe: set[str] = set()
+    unique_ppe: list[str] = []
+    for item in ppe:
+        if item not in seen_ppe:
+            seen_ppe.add(item)
+            unique_ppe.append(item)
+
+    seen_disposal: set[str] = set()
+    unique_disposal: list[str] = []
+    for item in disposal:
+        if item not in seen_disposal:
+            seen_disposal.add(item)
+            unique_disposal.append(item)
+
+    return {
+        "product_id": product.id,
+        "product_name": product.name,
+        "is_hazardous": getattr(product, "is_hazardous", False),
+        "hazard_codes": hazard_codes,
+        "ppe_requirements": unique_ppe,
+        "waste_disposal": unique_disposal,
+    }
+
+
+def check_inventory_safety(db: Session) -> list[dict]:
+    """Scan inventory for hazardous items without proper safety data.
+
+    Returns warnings for:
+    - Products marked ``is_hazardous`` but missing ``hazard_info``
+    - Products with ``hazard_info`` but no recognizable GHS codes
+    - Products marked ``is_hazardous`` but missing ``cas_number``
+    """
+    warnings: list[dict] = []
+
+    # Hazardous products missing hazard_info
+    products_no_info = db.scalars(
+        select(Product).where(
+            Product.is_hazardous == True,  # noqa: E712
+            (Product.hazard_info == None) | (Product.hazard_info == ""),  # noqa: E711
+        )
+    ).all()
+
+    for p in products_no_info:
+        warnings.append(
+            {
+                "product_id": p.id,
+                "product_name": p.name,
+                "catalog_number": p.catalog_number,
+                "warning_type": "missing_hazard_info",
+                "severity": "warning",
+                "message": (
+                    f"Product '{p.name}' (ID {p.id}) is marked hazardous but has no "
+                    f"hazard info. Please update with GHS hazard codes."
+                ),
+            }
+        )
+
+    # Hazardous products missing CAS number
+    products_no_cas = db.scalars(
+        select(Product).where(
+            Product.is_hazardous == True,  # noqa: E712
+            (Product.cas_number == None) | (Product.cas_number == ""),  # noqa: E711
+        )
+    ).all()
+
+    for p in products_no_cas:
+        warnings.append(
+            {
+                "product_id": p.id,
+                "product_name": p.name,
+                "catalog_number": p.catalog_number,
+                "warning_type": "missing_cas_number",
+                "severity": "info",
+                "message": (
+                    f"Product '{p.name}' (ID {p.id}) is hazardous but has no CAS number. "
+                    f"Adding CAS number enables automated SDS lookups."
+                ),
+            }
+        )
+
+    # Products with hazard_info but no recognizable GHS codes
+    products_bad_codes = db.scalars(
+        select(Product).where(
+            Product.is_hazardous == True,  # noqa: E712
+            Product.hazard_info != None,  # noqa: E711
+            Product.hazard_info != "",
+        )
+    ).all()
+
+    for p in products_bad_codes:
+        codes = _parse_hazard_codes(getattr(p, "hazard_info", "") or "")
+        if not codes:
+            warnings.append(
+                {
+                    "product_id": p.id,
+                    "product_name": p.name,
+                    "catalog_number": p.catalog_number,
+                    "warning_type": "unrecognized_hazard_codes",
+                    "severity": "info",
+                    "message": (
+                        f"Product '{p.name}' (ID {p.id}) has hazard info "
+                        f"'{p.hazard_info}' but no recognized GHS codes found. "
+                        f"Use standard H-codes (e.g. H225, H314)."
+                    ),
+                }
+            )
+
+    return warnings

--- a/tests/bdd/features/safety_alerts.feature
+++ b/tests/bdd/features/safety_alerts.feature
@@ -1,0 +1,62 @@
+# Safety Alerts — PPE requirements, waste disposal, and consumption reminders
+Feature: Safety Alerts with PPE Warnings
+  As a lab manager
+  I want PPE recommendations and safety reminders when working with hazardous chemicals
+  So that I can protect lab personnel and follow proper safety protocols
+
+  # PPE for flammable chemicals
+  Scenario: Get PPE requirements for flammable chemical
+    Given a product with hazard info "H225 Highly flammable liquid"
+    When I request PPE requirements for that product
+    Then the response should contain "Use in fume hood"
+    And the response should contain "no open flames"
+    And the response should contain "fire-resistant lab coat"
+    And the response should contain "safety goggles"
+
+  # PPE for corrosive chemicals
+  Scenario: Get PPE requirements for corrosive chemical
+    Given a product with hazard info "H314 Causes severe skin burns"
+    When I request PPE requirements for that product
+    Then the response should contain "Acid-resistant gloves"
+    And the response should contain "face shield"
+    And the response should contain "chemical apron"
+
+  # PPE for multiple hazard codes
+  Scenario: Get PPE requirements for chemical with multiple hazards
+    Given a product with hazard info "H225 H314 H331"
+    When I request PPE requirements for that product
+    Then the response should contain PPE items from multiple hazard categories
+    And the response hazard codes should be "H225", "H314", "H331"
+
+  # Safety reminder on hazardous item consumption
+  Scenario: Safety reminder on hazardous item consumption
+    Given a hazardous product "Acetone" with hazard info "H225 H319"
+    And an inventory item for that product with quantity 100
+    When I consume 10 units of that item
+    Then the response should include a safety reminder
+    And the safety reminder should contain PPE requirements
+
+  # No safety reminder for non-hazardous items
+  Scenario: No safety reminder for non-hazardous consumption
+    Given a non-hazardous product "Sodium Chloride"
+    And an inventory item for that product with quantity 500
+    When I consume 50 units of that item
+    Then the response should not include a safety reminder
+
+  # Inventory safety scan
+  Scenario: Inventory safety scan detects missing hazard info
+    Given a hazardous product "Sulfuric Acid" with no hazard info
+    When I run the inventory safety scan
+    Then the scan should return a warning about missing hazard info
+    And the warning should reference "Sulfuric Acid"
+
+  # Inventory safety scan - missing CAS
+  Scenario: Inventory safety scan detects missing CAS number
+    Given a hazardous product "Hydrochloric Acid" with hazard info "H314" but no CAS number
+    When I run the inventory safety scan
+    Then the scan should return a warning about missing CAS number
+
+  # Unknown hazard codes
+  Scenario: Get PPE for unknown hazard code
+    When I request PPE requirements for hazard code "H999"
+    Then the response should suggest consulting SDS

--- a/tests/bdd/step_defs/test_safety_alerts.py
+++ b/tests/bdd/step_defs/test_safety_alerts.py
@@ -1,0 +1,298 @@
+"""BDD step definitions for safety_alerts.feature."""
+
+from __future__ import annotations
+
+import pytest
+from pytest_bdd import given, when, then, parsers, scenarios
+
+from lab_manager.models.product import Product
+from lab_manager.models.inventory import InventoryItem
+
+scenarios("../features/safety_alerts.feature")
+
+
+# Shared context: store state per-scenario via pytest stash
+@pytest.fixture
+def safety_ctx():
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Given steps
+# ---------------------------------------------------------------------------
+
+
+@given('a product with hazard info "H225 Highly flammable liquid"')
+def product_flammable(db, safety_ctx):
+    p = Product(
+        catalog_number="FLAM-001",
+        name="Flammable Test Chemical",
+        hazard_info="H225 Highly flammable liquid",
+        is_hazardous=True,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given('a product with hazard info "H314 Causes severe skin burns"')
+def product_corrosive(db, safety_ctx):
+    p = Product(
+        catalog_number="CORR-001",
+        name="Corrosive Test Chemical",
+        hazard_info="H314 Causes severe skin burns",
+        is_hazardous=True,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given('a product with hazard info "H225 H314 H331"')
+def product_multi_hazard(db, safety_ctx):
+    p = Product(
+        catalog_number="MULTI-001",
+        name="Multi-Hazard Chemical",
+        hazard_info="H225 H314 H331",
+        is_hazardous=True,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given(parsers.parse('a hazardous product "{name}" with hazard info "{hazard_info}"'))
+def hazardous_product_with_info(db, safety_ctx, name, hazard_info):
+    p = Product(
+        catalog_number=f"SAFE-{name[:4].upper()}",
+        name=name,
+        hazard_info=hazard_info,
+        is_hazardous=True,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given(parsers.parse('a non-hazardous product "{name}"'))
+def non_hazardous_product(db, safety_ctx, name):
+    p = Product(
+        catalog_number=f"NON-{name[:4].upper()}",
+        name=name,
+        is_hazardous=False,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given(parsers.parse('a hazardous product "{name}" with no hazard info'))
+def hazardous_product_no_info(db, safety_ctx, name):
+    p = Product(
+        catalog_number=f"NOH-{name[:4].upper()}",
+        name=name,
+        is_hazardous=True,
+        hazard_info=None,
+        cas_number="7664-93-9",
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given(
+    parsers.parse(
+        'a hazardous product "{name}" with hazard info "{hazard_info}" but no CAS number'
+    )
+)
+def hazardous_product_no_cas(db, safety_ctx, name, hazard_info):
+    p = Product(
+        catalog_number=f"NOC-{name[:4].upper()}",
+        name=name,
+        is_hazardous=True,
+        hazard_info=hazard_info,
+        cas_number=None,
+    )
+    db.add(p)
+    db.flush()
+    db.refresh(p)
+    safety_ctx["product_id"] = p.id
+    safety_ctx["product"] = p
+
+
+@given(parsers.parse("an inventory item for that product with quantity {qty:d}"))
+def inventory_item_for_product(db, safety_ctx, qty):
+    product = safety_ctx["product"]
+    item = InventoryItem(
+        product_id=product.id,
+        quantity_on_hand=qty,
+        status="available",
+    )
+    db.add(item)
+    db.flush()
+    db.refresh(item)
+    safety_ctx["inventory_id"] = item.id
+
+
+# ---------------------------------------------------------------------------
+# When steps
+# ---------------------------------------------------------------------------
+
+
+@when("I request PPE requirements for that product")
+def request_ppe_for_product(api, safety_ctx):
+    product_id = safety_ctx["product_id"]
+    response = api.get(f"/api/v1/safety/ppe/{product_id}")
+    assert response.status_code == 200, f"Got {response.status_code}: {response.text}"
+    safety_ctx["ppe_response"] = response.json()
+
+
+@when(parsers.parse('I request PPE requirements for hazard code "{hazard_code}"'))
+def request_ppe_by_code(safety_ctx, hazard_code):
+    from lab_manager.services.safety import get_ppe_requirements
+
+    safety_ctx["ppe_result"] = get_ppe_requirements(hazard_code)
+
+
+@when(parsers.parse("I consume {qty:d} units of that item"))
+def consume_units(api, safety_ctx, qty):
+    inventory_id = safety_ctx["inventory_id"]
+    response = api.post(
+        f"/api/v1/inventory/{inventory_id}/consume",
+        json={
+            "quantity": qty,
+            "consumed_by": "test-user",
+            "purpose": "testing",
+        },
+    )
+    assert response.status_code == 200, f"Got {response.status_code}: {response.text}"
+    safety_ctx["consume_response"] = response.json()
+
+
+@when("I run the inventory safety scan")
+def run_safety_scan(api, safety_ctx):
+    response = api.get("/api/v1/safety/inventory-scan")
+    assert response.status_code == 200, f"Got {response.status_code}: {response.text}"
+    safety_ctx["scan_result"] = response.json()
+
+
+# ---------------------------------------------------------------------------
+# Then steps
+# ---------------------------------------------------------------------------
+
+
+@then(parsers.parse('the response should contain "{expected}"'))
+def response_contains(safety_ctx, expected):
+    # Check PPE API response
+    ppe_resp = safety_ctx.get("ppe_response")
+    if ppe_resp:
+        all_ppe = " ".join(ppe_resp.get("ppe_requirements", []))
+        assert expected in all_ppe, f"Expected '{expected}' in '{all_ppe}'"
+        return
+
+    # Check direct PPE result
+    ppe_result = safety_ctx.get("ppe_result")
+    if ppe_result:
+        all_ppe = " ".join(ppe_result)
+        assert expected in all_ppe, f"Expected '{expected}' in '{all_ppe}'"
+        return
+
+    # Check consume response safety reminder
+    consume_resp = safety_ctx.get("consume_response")
+    if consume_resp and "safety_reminder" in consume_resp:
+        all_ppe = " ".join(consume_resp["safety_reminder"].get("ppe_requirements", []))
+        assert expected in all_ppe, f"Expected '{expected}' in '{all_ppe}'"
+        return
+
+    pytest.fail("No PPE response or result found in context")
+
+
+@then("the response should contain PPE items from multiple hazard categories")
+def response_multiple_categories(safety_ctx):
+    ppe_resp = safety_ctx.get("ppe_response")
+    assert ppe_resp is not None
+    ppe = ppe_resp.get("ppe_requirements", [])
+    assert len(ppe) >= 3, f"Expected >=3 PPE items, got {len(ppe)}: {ppe}"
+
+
+@then(parsers.parse("the response hazard codes should be {codes}"))
+def response_hazard_codes(safety_ctx, codes):
+    expected = [c.strip().strip('"') for c in codes.split(",")]
+    ppe_resp = safety_ctx.get("ppe_response")
+    assert ppe_resp is not None
+    actual = ppe_resp.get("hazard_codes", [])
+    assert actual == expected, f"Expected {expected}, got {actual}"
+
+
+@then("the response should include a safety reminder")
+def response_has_safety_reminder(safety_ctx):
+    resp = safety_ctx.get("consume_response")
+    assert resp is not None, "No consume response"
+    assert "safety_reminder" in resp, f"Expected safety_reminder in response: {resp}"
+
+
+@then("the safety reminder should contain PPE requirements")
+def safety_reminder_has_ppe(safety_ctx):
+    resp = safety_ctx.get("consume_response")
+    assert resp is not None
+    reminder = resp.get("safety_reminder", {})
+    ppe = reminder.get("ppe_requirements", [])
+    assert len(ppe) > 0, f"Expected PPE requirements in safety reminder: {reminder}"
+
+
+@then("the response should not include a safety reminder")
+def response_no_safety_reminder(safety_ctx):
+    resp = safety_ctx.get("consume_response")
+    assert resp is not None, "No consume response"
+    assert "safety_reminder" not in resp, (
+        f"Did not expect safety_reminder in response: {resp}"
+    )
+
+
+@then("the scan should return a warning about missing hazard info")
+def scan_missing_hazard_info(safety_ctx):
+    result = safety_ctx.get("scan_result")
+    assert result is not None, "No scan result"
+    warnings = result.get("warnings", [])
+    found = any(w["warning_type"] == "missing_hazard_info" for w in warnings)
+    assert found, f"Expected missing_hazard_info warning, got: {warnings}"
+
+
+@then(parsers.parse('the warning should reference "{name}"'))
+def scan_warning_references_name(safety_ctx, name):
+    result = safety_ctx.get("scan_result")
+    assert result is not None, "No scan result"
+    warnings = result.get("warnings", [])
+    found = any(name in w.get("message", "") for w in warnings)
+    assert found, f"Expected warning referencing '{name}', got: {warnings}"
+
+
+@then("the scan should return a warning about missing CAS number")
+def scan_missing_cas(safety_ctx):
+    result = safety_ctx.get("scan_result")
+    assert result is not None, "No scan result"
+    warnings = result.get("warnings", [])
+    found = any(w["warning_type"] == "missing_cas_number" for w in warnings)
+    assert found, f"Expected missing_cas_number warning, got: {warnings}"
+
+
+@then("the response should suggest consulting SDS")
+def response_suggests_sds(safety_ctx):
+    ppe_result = safety_ctx.get("ppe_result")
+    assert ppe_result is not None
+    all_ppe = " ".join(ppe_result)
+    assert "SDS" in all_ppe or "Consult" in all_ppe, (
+        f"Expected SDS suggestion, got: {ppe_result}"
+    )

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1,0 +1,349 @@
+"""Unit tests for the safety service — GHS hazard mapping, PPE, disposal, inventory scan."""
+
+from __future__ import annotations
+
+
+from lab_manager.models.product import Product
+from lab_manager.services.safety import (
+    GHS_HAZARD_MAP,
+    _parse_hazard_codes,
+    check_inventory_safety,
+    get_product_safety_info,
+    get_ppe_requirements,
+    get_waste_disposal_guide,
+)
+
+
+# ---------------------------------------------------------------------------
+# GHS Hazard Mapping
+# ---------------------------------------------------------------------------
+
+
+class TestGHSHazardMap:
+    """Test the GHS_HAZARD_MAP data structure."""
+
+    def test_map_has_entries(self):
+        assert len(GHS_HAZARD_MAP) > 0
+
+    def test_each_entry_has_required_keys(self):
+        for code, entry in GHS_HAZARD_MAP.items():
+            assert "category" in entry, f"{code} missing 'category'"
+            assert "ppe" in entry, f"{code} missing 'ppe'"
+            assert "disposal" in entry, f"{code} missing 'disposal'"
+
+    def test_each_entry_values_are_nonempty(self):
+        for code, entry in GHS_HAZARD_MAP.items():
+            assert entry["category"], f"{code} has empty category"
+            assert entry["ppe"], f"{code} has empty ppe"
+            assert entry["disposal"], f"{code} has empty disposal"
+
+    def test_physical_hazards_present(self):
+        """H200-H299 range (explosive, flammable, etc.) has entries."""
+        physical_codes = [c for c in GHS_HAZARD_MAP if c.startswith("H2")]
+        assert len(physical_codes) >= 5, "Expected >=5 physical hazard entries"
+
+    def test_health_hazards_present(self):
+        """H300-H399 range has entries."""
+        health_codes = [c for c in GHS_HAZARD_MAP if c.startswith("H3")]
+        assert len(health_codes) >= 5, "Expected >=5 health hazard entries"
+
+    def test_environmental_hazards_present(self):
+        """H400-H499 range has entries."""
+        env_codes = [c for c in GHS_HAZARD_MAP if c.startswith("H4")]
+        assert len(env_codes) >= 3, "Expected >=3 environmental hazard entries"
+
+
+# ---------------------------------------------------------------------------
+# Hazard Code Parsing
+# ---------------------------------------------------------------------------
+
+
+class TestParseHazardCodes:
+    def test_single_code(self):
+        assert _parse_hazard_codes("H225") == ["H225"]
+
+    def test_multiple_codes(self):
+        assert _parse_hazard_codes("H225 H314 H331") == ["H225", "H314", "H331"]
+
+    def test_code_in_sentence(self):
+        result = _parse_hazard_codes("H225 Highly flammable liquid and vapour")
+        assert result == ["H225"]
+
+    def test_mixed_case(self):
+        result = _parse_hazard_codes("h225 h314")
+        assert result == ["H225", "H314"]
+
+    def test_empty_string(self):
+        assert _parse_hazard_codes("") == []
+
+    def test_none(self):
+        assert _parse_hazard_codes(None) == []
+
+    def test_euh_code(self):
+        result = _parse_hazard_codes("EUH071")
+        assert result == ["EUH071"]
+
+    def test_no_codes_found(self):
+        assert _parse_hazard_codes("just some text without codes") == []
+
+
+# ---------------------------------------------------------------------------
+# PPE Requirements
+# ---------------------------------------------------------------------------
+
+
+class TestPPERequirements:
+    def test_flammable_chemical(self):
+        result = get_ppe_requirements("H225")
+        assert "Use in fume hood" in result
+        assert "no open flames" in result
+        assert "fire-resistant lab coat" in result
+        assert "safety goggles" in result
+
+    def test_corrosive_chemical(self):
+        result = get_ppe_requirements("H314")
+        assert "Acid-resistant gloves" in result
+        assert "face shield" in result
+        assert "chemical apron" in result
+
+    def test_acute_toxic(self):
+        result = get_ppe_requirements("H300")
+        assert "fume hood" in " ".join(result).lower()
+        assert any("face shield" in item for item in result)
+
+    def test_inhalation_hazard(self):
+        result = get_ppe_requirements("H331")
+        assert "fume hood" in " ".join(result).lower()
+
+    def test_environmental(self):
+        result = get_ppe_requirements("H400")
+        assert len(result) > 0
+
+    def test_unknown_code_returns_sds_guidance(self):
+        result = get_ppe_requirements("H999")
+        assert len(result) == 1
+        assert "SDS" in result[0]
+
+    def test_case_insensitive(self):
+        result_lower = get_ppe_requirements("h225")
+        result_upper = get_ppe_requirements("H225")
+        assert result_lower == result_upper
+
+    def test_whitespace_stripped(self):
+        result = get_ppe_requirements("  H225  ")
+        assert "Use in fume hood" in result
+
+    def test_returns_list(self):
+        result = get_ppe_requirements("H225")
+        assert isinstance(result, list)
+        for item in result:
+            assert isinstance(item, str)
+
+
+# ---------------------------------------------------------------------------
+# Waste Disposal Guide
+# ---------------------------------------------------------------------------
+
+
+class TestWasteDisposalGuide:
+    def test_flammable_disposal(self):
+        result = get_waste_disposal_guide("H225")
+        assert "flammable" in result.lower()
+        assert "waste" in result.lower()
+
+    def test_corrosive_disposal(self):
+        result = get_waste_disposal_guide("H314")
+        assert "neutralize" in result.lower() or "neutralise" in result.lower()
+
+    def test_environmental_disposal(self):
+        result = get_waste_disposal_guide("H400")
+        assert "drains" in result.lower()
+        assert "separately" in result.lower()
+
+    def test_unknown_code_returns_generic(self):
+        result = get_waste_disposal_guide("H999")
+        assert "institutional" in result.lower() or "procedures" in result.lower()
+
+    def test_returns_string(self):
+        result = get_waste_disposal_guide("H225")
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_carcinogen_disposal(self):
+        result = get_waste_disposal_guide("H350")
+        assert "carcinogen" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Product Safety Info
+# ---------------------------------------------------------------------------
+
+
+class TestProductSafetyInfo:
+    def test_product_with_single_hazard(self):
+        product = Product(
+            id=1,
+            name="Test Chemical",
+            catalog_number="TEST-001",
+            hazard_info="H225",
+            is_hazardous=True,
+        )
+        result = get_product_safety_info(product)
+        assert result["product_id"] == 1
+        assert result["product_name"] == "Test Chemical"
+        assert result["is_hazardous"] is True
+        assert result["hazard_codes"] == ["H225"]
+        assert len(result["ppe_requirements"]) > 0
+        assert len(result["waste_disposal"]) > 0
+
+    def test_product_with_multiple_hazards(self):
+        product = Product(
+            id=2,
+            name="Multi Hazard",
+            catalog_number="MH-001",
+            hazard_info="H225 H314 H400",
+            is_hazardous=True,
+        )
+        result = get_product_safety_info(product)
+        assert result["hazard_codes"] == ["H225", "H314", "H400"]
+        # Should have PPE from all three codes
+        assert len(result["ppe_requirements"]) >= 3
+        assert len(result["waste_disposal"]) >= 3
+
+    def test_product_no_hazard_info(self):
+        product = Product(
+            id=3,
+            name="Safe Chemical",
+            catalog_number="SAFE-001",
+            hazard_info=None,
+            is_hazardous=False,
+        )
+        result = get_product_safety_info(product)
+        assert result["hazard_codes"] == []
+        assert result["ppe_requirements"] == []
+        assert result["waste_disposal"] == []
+        assert result["is_hazardous"] is False
+
+    def test_deduplication_of_ppe(self):
+        """Multiple codes with overlapping PPE should not duplicate."""
+        product = Product(
+            id=4,
+            name="Duplicate PPE",
+            catalog_number="DUP-001",
+            hazard_info="H302 H312",  # Both have "Wear nitrile gloves"
+            is_hazardous=True,
+        )
+        result = get_product_safety_info(product)
+        ppe = result["ppe_requirements"]
+        # Count occurrences of "Wear nitrile gloves"
+        glove_count = sum(1 for p in ppe if "nitrile gloves" in p.lower())
+        assert glove_count == 1, f"Expected 1 glove entry, got {glove_count}: {ppe}"
+
+
+# ---------------------------------------------------------------------------
+# Inventory Safety Scan (unit-level with mock-like DB)
+# ---------------------------------------------------------------------------
+
+
+class TestInventorySafetyScan:
+    def test_hazardous_without_hazard_info(self, db_session):
+        """Products marked hazardous but missing hazard_info generate a warning."""
+        p = Product(
+            catalog_number="NOH-001",
+            name="Missing Info Chemical",
+            is_hazardous=True,
+            hazard_info=None,
+            cas_number="1234-56-7",
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        assert len(warnings) >= 1
+        assert any(w["warning_type"] == "missing_hazard_info" for w in warnings)
+
+    def test_hazardous_without_cas(self, db_session):
+        """Products marked hazardous but missing CAS number generate a warning."""
+        p = Product(
+            catalog_number="NOC-001",
+            name="No CAS Chemical",
+            is_hazardous=True,
+            hazard_info="H225",
+            cas_number=None,
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        assert any(w["warning_type"] == "missing_cas_number" for w in warnings)
+
+    def test_non_hazardous_products_not_flagged(self, db_session):
+        """Non-hazardous products should not generate warnings."""
+        p = Product(
+            catalog_number="SAFE-002",
+            name="Safe Chemical",
+            is_hazardous=False,
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        product_warnings = [
+            w for w in warnings if w.get("product_name") == "Safe Chemical"
+        ]
+        assert len(product_warnings) == 0
+
+    def test_unrecognized_hazard_codes(self, db_session):
+        """Hazardous products with hazard_info but no H-codes get flagged."""
+        p = Product(
+            catalog_number="BAD-001",
+            name="Bad Codes Chemical",
+            is_hazardous=True,
+            hazard_info="Corrosive and toxic",
+            cas_number="5678-90-1",
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        assert any(w["warning_type"] == "unrecognized_hazard_codes" for w in warnings)
+
+    def test_fully_documented_product_no_warning(self, db_session):
+        """A product with hazard_info, CAS, and valid H-codes should not be flagged."""
+        p = Product(
+            catalog_number="GOOD-001",
+            name="Well Documented Chemical",
+            is_hazardous=True,
+            hazard_info="H225 H314",
+            cas_number="9999-99-9",
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        product_warnings = [
+            w for w in warnings if w.get("product_name") == "Well Documented Chemical"
+        ]
+        assert len(product_warnings) == 0
+
+    def test_warning_has_required_fields(self, db_session):
+        """Each warning dict has the expected keys."""
+        p = Product(
+            catalog_number="FIELD-001",
+            name="Field Test Chemical",
+            is_hazardous=True,
+            hazard_info=None,
+        )
+        db_session.add(p)
+        db_session.flush()
+
+        warnings = check_inventory_safety(db_session)
+        matching = [w for w in warnings if w["product_name"] == "Field Test Chemical"]
+        assert len(matching) >= 1
+        for w in matching:
+            assert "product_id" in w
+            assert "product_name" in w
+            assert "catalog_number" in w
+            assert "warning_type" in w
+            assert "severity" in w
+            assert "message" in w


### PR DESCRIPTION
## Summary
- Add `src/lab_manager/services/safety.py` with GHS hazard code mapping (40+ codes) covering physical (H200-H299), health (H300-H399), and environmental (H400-H499) hazard classes
- Add `GET /api/v1/safety/ppe/{product_id}`, `GET /api/v1/safety/disposal/{hazard_code}`, `GET /api/v1/safety/inventory-scan` endpoints
- Hook into inventory consumption: hazardous product consumption now includes a safety reminder with PPE requirements in the response
- Inventory safety scan detects: hazardous products missing hazard info, missing CAS numbers, and unrecognized hazard codes

## Test plan
- [x] 39 unit tests in `tests/test_safety.py` — GHS map validation, PPE requirements, waste disposal, product safety info, inventory scan
- [x] 8 BDD scenarios in `tests/bdd/features/safety_alerts.feature` — flammable PPE, corrosive PPE, multi-hazard, consumption safety reminder, non-hazardous skip, inventory scan
- [x] All 47 new tests pass; no regressions in existing test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)