### PR TITLE
fix(validation): add min_length=1 to order request and product fields

### DIFF
--- a/src/lab_manager/api/routes/order_requests.py
+++ b/src/lab_manager/api/routes/order_requests.py
@@ -40,8 +40,8 @@ _MAX_QUANTITY = 1_000_000
 class OrderRequestCreate(BaseModel):
     product_id: Optional[int] = None
     vendor_id: Optional[int] = None
-    catalog_number: Optional[str] = Field(default=None, max_length=100)
-    description: Optional[str] = Field(default=None, max_length=1000)
+    catalog_number: Optional[str] = Field(default=None, min_length=1, max_length=100)
+    description: Optional[str] = Field(default=None, min_length=1, max_length=1000)
     quantity: Decimal = Field(
         default=Decimal("1"), gt=0, le=Decimal(str(_MAX_QUANTITY))
     )

--- a/src/lab_manager/api/routes/products.py
+++ b/src/lab_manager/api/routes/products.py
@@ -67,8 +67,10 @@ class ProductCreate(BaseModel):
 
 
 class ProductUpdate(BaseModel):
-    catalog_number: Optional[str] = PydanticField(default=None, max_length=100)
-    name: Optional[str] = PydanticField(default=None, max_length=500)
+    catalog_number: Optional[str] = PydanticField(
+        default=None, min_length=1, max_length=100
+    )
+    name: Optional[str] = PydanticField(default=None, min_length=1, max_length=500)
     vendor_id: Optional[int] = None
     category: Optional[str] = PydanticField(default=None, max_length=100)
     cas_number: Optional[str] = PydanticField(default=None, max_length=30)


### PR DESCRIPTION
## Summary
- Add `min_length=1` to `OrderRequestCreate.catalog_number` and `OrderRequestCreate.description` to prevent empty string submissions
- Add `min_length=1` to `ProductUpdate.catalog_number` and `ProductUpdate.name` to prevent empty string updates
- `ProductCreate` already had these constraints; this makes `ProductUpdate` consistent

## Test plan
- [ ] Verify POST /order-requests rejects empty string catalog_number/description
- [ ] Verify PATCH /products rejects empty string name/catalog_number
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)