### PR TITLE
fix(telemetry): add threading.Lock to rate limiter to prevent race condition

### DIFF
--- a/src/lab_manager/api/routes/telemetry.py
+++ b/src/lab_manager/api/routes/telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
@@ -18,6 +19,7 @@ router = APIRouter(dependencies=[Depends(require_permission("view_analytics"))])
 
 # In-memory rate limiting: 1 event per user per page per minute
 _rate_limits: dict[str, float] = {}
+_rate_lock = threading.Lock()
 _RATE_LIMIT_WINDOW = 60  # seconds
 _MAX_STORE_SIZE = 10_000  # evict stale entries above this
 
@@ -46,13 +48,14 @@ def record_event(
     user = getattr(request.state, "user", "system")
     key = _rate_limit_key(user, page or "__global")
 
-    now = time.monotonic()
-    last = _rate_limits.get(key, 0)
-    if now - last < _RATE_LIMIT_WINDOW:
-        return {"status": "rate_limited"}
+    with _rate_lock:
+        now = time.monotonic()
+        last = _rate_limits.get(key, 0)
+        if now - last < _RATE_LIMIT_WINDOW:
+            return {"status": "rate_limited"}
 
-    _evict_stale()
-    _rate_limits[key] = now
+        _evict_stale()
+        _rate_limits[key] = now
 
     event = UsageEvent(
         user_email=user,

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -167,3 +167,35 @@ def test_evict_stale_entries(client, db_session):
     finally:
         tel_mod._MAX_STORE_SIZE = original_max
         tel_mod._rate_limits.clear()
+
+
+def test_rate_limit_concurrent_thread_safety(client, db_session):
+    """Concurrent requests for the same user+page must be rate-limited.
+
+    Without the lock, threads can both read the old timestamp and both
+    pass the rate-limit check before either writes the new one.
+    """
+    import threading
+
+    results: list[str] = []
+    barrier = threading.Barrier(2)
+
+    def post_event():
+        barrier.wait()
+        resp = client.post(
+            "/api/v1/telemetry/event",
+            params={"event_type": "page_view", "page": "/race-test"},
+        )
+        results.append(resp.json()["status"])
+
+    t1 = threading.Thread(target=post_event)
+    t2 = threading.Thread(target=post_event)
+    t1.start()
+    t2.start()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    # One request must succeed, the other must be rate-limited.
+    # Without the lock this test is flaky because both can succeed.
+    assert results.count("ok") == 1
+    assert results.count("rate_limited") == 1


### PR DESCRIPTION
## Summary
- Add `threading.Lock` (`_rate_lock`) around the rate-limit check-and-update block in `record_event`
- Without the lock, concurrent requests for the same user+page could both pass the rate limit check because the read (`_rate_limits.get()`) and write (`_rate_limits[key] = now`) were not atomic
- Add thread-safety test: `test_rate_limit_concurrent_thread_safety` uses `threading.Barrier` to ensure two threads hit the endpoint simultaneously — exactly one must succeed, the other must be rate-limited

## Bug detail
```
Thread A: last = _rate_limits.get(key, 0)  # reads 0.0
Thread B: last = _rate_limits.get(key, 0)  # reads 0.0  (still 0!)
Thread A: now - 0.0 > 60 → passes → _rate_limits[key] = now
Thread B: now - 0.0 > 60 → passes → _rate_limits[key] = now  (DUPLICATE!)
```
Both requests write a UsageEvent when only one should be allowed per 60s window.

## Test plan
- [x] 9/9 telemetry tests pass including new `test_rate_limit_concurrent_thread_safety`
- [ ] Existing rate-limit behavior preserved (sequential requests still limited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)