### PR TITLE
fix(import): import valid CSV rows even when other rows have errors

### DIFF
--- a/src/lab_manager/api/routes/import_routes.py
+++ b/src/lab_manager/api/routes/import_routes.py
@@ -188,14 +188,15 @@ def import_vendors(
         new_vendors.append(Vendor(**data))
         imported += 1
 
-    if all_errors:
+    if not new_vendors and all_errors:
         return {"imported": 0, "errors": all_errors, "skipped": skipped}
 
     for v in new_vendors:
         db.add(v)
-    db.commit()
+    if new_vendors:
+        db.commit()
 
-    return {"imported": imported, "errors": [], "skipped": skipped}
+    return {"imported": imported, "errors": all_errors, "skipped": skipped}
 
 
 # ---------------------------------------------------------------------------
@@ -339,14 +340,15 @@ def import_products(
         new_products.append(Product(**data))
         imported += 1
 
-    if all_errors:
+    if not new_products and all_errors:
         return {"imported": 0, "errors": all_errors, "skipped": skipped}
 
     for p in new_products:
         db.add(p)
-    db.commit()
+    if new_products:
+        db.commit()
 
-    return {"imported": imported, "errors": [], "skipped": skipped}
+    return {"imported": imported, "errors": all_errors, "skipped": skipped}
 
 
 # ---------------------------------------------------------------------------
@@ -537,11 +539,12 @@ def import_inventory(
         new_items.append(InventoryItem(**data))
         imported += 1
 
-    if all_errors:
+    if not new_items and all_errors:
         return {"imported": 0, "errors": all_errors, "skipped": 0}
 
     for item in new_items:
         db.add(item)
-    db.commit()
+    if new_items:
+        db.commit()
 
-    return {"imported": imported, "errors": [], "skipped": 0}
+    return {"imported": imported, "errors": all_errors, "skipped": 0}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -235,3 +235,48 @@ class TestImportEdgeCases:
         resp = _upload(client, "vendors", csv)
         data = resp.json()
         assert data["imported"] == 1
+
+
+class TestImportPartialSuccess:
+    """Valid rows must be imported even when other rows have errors."""
+
+    def test_vendors_partial_success(self, client):
+        csv = _csv_bytes(
+            "name,website",
+            "GoodVendor,https://good.com",
+            ",",  # row 3: empty name -> error
+            "AnotherGood,https://another.com",
+        )
+        resp = _upload(client, "vendors", csv)
+        data = resp.json()
+        assert data["imported"] == 2
+        assert len(data["errors"]) >= 1
+        assert any("required" in e["message"] for e in data["errors"])
+
+    def test_products_partial_success(self, client):
+        _upload(client, "vendors", _csv_bytes("name", "TestVendor"))
+        csv = _csv_bytes(
+            "catalog_number,name,vendor_id",
+            "GOOD-001,Good Product,1",
+            ",Bad Product,1",  # missing catalog_number
+            "GOOD-002,Another Good,1",
+        )
+        resp = _upload(client, "products", csv)
+        data = resp.json()
+        assert data["imported"] == 2
+        assert len(data["errors"]) >= 1
+
+    def test_inventory_partial_success(self, client):
+        _upload(
+            client, "products", _csv_bytes("catalog_number,name", "INV-PS,PS Product")
+        )
+        csv = _csv_bytes(
+            "product_id,quantity_on_hand,status",
+            "1,5,available",
+            "9999,10,available",  # bad product_id
+            "1,3,available",
+        )
+        resp = _upload(client, "inventory", csv)
+        data = resp.json()
+        assert data["imported"] == 2
+        assert len(data["errors"]) >= 1


### PR DESCRIPTION
## Summary
- All three CSV import endpoints (vendors, products, inventory) previously discarded ALL rows if ANY single row had a validation error
- A CSV with 4999 valid rows and 1 invalid row would import **zero** rows
- Now valid rows are committed and errors are returned alongside the imported count
- Added `TestImportPartialSuccess` with 3 tests covering each endpoint

## Bug detail
```python
# Before (vendors, products, inventory):
if all_errors:
    return {"imported": 0, "errors": all_errors, "skipped": skipped}
# ALL valid rows discarded!

# After:
if not new_vendors and all_errors:
    return {"imported": 0, "errors": all_errors, "skipped": skipped}
# Only short-circuit when there are NO valid rows
# Otherwise commit valid rows and return errors alongside imported count
```

## Test plan
- [x] 22/22 import tests pass including 3 new `TestImportPartialSuccess` tests
- [ ] Verify CSV with mixed valid/invalid rows imports valid ones
- [ ] Verify CSV with ALL invalid rows returns `imported: 0` with errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)