### PR TITLE
fix(order-requests): handle IntegrityError in staff auto-creation race condition

### DIFF
--- a/src/lab_manager/api/routes/order_requests.py
+++ b/src/lab_manager/api/routes/order_requests.py
@@ -9,6 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from lab_manager.api.deps import get_db, get_or_404
@@ -86,10 +87,16 @@ def _get_current_staff(request: Request, db: Session) -> Staff:
     user_name = getattr(request.state, "user", "system")
     staff = db.scalars(select(Staff).where(Staff.name == user_name)).first()
     if not staff:
-        # In dev mode (auth_enabled=false), auto-create a staff record
-        staff = Staff(name=user_name, role="grad_student", is_active=True)
-        db.add(staff)
-        db.flush()
+        try:
+            staff = Staff(name=user_name, role="grad_student", is_active=True)
+            db.add(staff)
+            db.flush()
+        except IntegrityError:
+            # Concurrent request may have inserted this staff member
+            db.rollback()
+            staff = db.scalars(select(Staff).where(Staff.name == user_name)).first()
+            if not staff:
+                raise
     return staff
 
 

--- a/tests/test_order_requests.py
+++ b/tests/test_order_requests.py
@@ -257,3 +257,18 @@ def test_get_nonexistent_request(student_client):
 def test_approve_nonexistent_request(admin_client):
     resp = admin_client.post("/api/v1/requests/9999/approve", json={})
     assert resp.status_code == 404
+
+
+def test_new_user_auto_creates_staff(client, db_session):
+    """A request from a brand-new user should auto-create a Staff record."""
+    new_user = f"new_user_{id(client)}"
+    client.headers["X-User"] = new_user
+    resp = _create_request(client)
+    assert resp.status_code == 201
+
+    # Verify staff was auto-created
+    from sqlalchemy import select
+
+    staff = db_session.scalars(select(Staff).where(Staff.name == new_user)).first()
+    assert staff is not None
+    assert staff.role == "grad_student"


### PR DESCRIPTION
## Summary
- The `_get_current_staff` helper auto-creates a Staff record when auth is disabled and the user doesn't exist
- Two concurrent requests with the same new `X-User` header could both fail to find the staff, both try to create one
- Without a unique constraint on `Staff.name`, this silently creates duplicate records
- If a unique constraint is added later, this would crash with an unhandled `IntegrityError`
- Fix: wrap the auto-creation in `try/except IntegrityError` and re-query on collision

## Test plan
- [x] Added `test_new_user_auto_creates_staff` — verifies a brand-new user auto-creates staff
- [x] 18/18 order request tests pass
- [ ] Verify no duplicate staff records are created under concurrent requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)