### PR TITLE
fix(rag): add cache eviction to prevent unbounded memory growth

### DIFF
--- a/src/lab_manager/services/rag.py
+++ b/src/lab_manager/services/rag.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 
 from sqlalchemy import text
 from sqlmodel import Session
@@ -543,6 +544,19 @@ def _fallback_search(question: str) -> dict:
 # Simple TTL cache for identical questions (5-minute window)
 _CACHE: dict[str, tuple[float, dict]] = {}
 _CACHE_TTL_S = 300  # 5 minutes
+_CACHE_MAX_SIZE = 500
+
+
+def _evict_cache() -> None:
+    """Remove stale entries and enforce max size on the RAG cache."""
+    now = time.time()
+    stale = [k for k, (ts, _) in _CACHE.items() if now - ts > _CACHE_TTL_S]
+    for k in stale:
+        del _CACHE[k]
+    if len(_CACHE) > _CACHE_MAX_SIZE:
+        oldest = sorted(_CACHE.items(), key=lambda item: item[1][0])
+        for k, _ in oldest[: len(_CACHE) - _CACHE_MAX_SIZE]:
+            del _CACHE[k]
 
 
 def _cache_key(question: str) -> str:
@@ -665,5 +679,6 @@ def ask(question: str, db: Session) -> dict:
             "aggregation": plan.get("aggregation", ""),
             "result_shape": plan.get("result", ""),
         }
+    _evict_cache()
     _CACHE[key] = (time.time(), result)
     return result

--- a/tests/test_rag_service_coverage.py
+++ b/tests/test_rag_service_coverage.py
@@ -196,3 +196,47 @@ class TestAsk:
             assert result["answer"] == "There is 1 vendor."
             assert result["sql"] == "SELECT * FROM vendors"
             assert result["row_count"] == 1
+
+
+class TestCacheEviction:
+    """Regression tests for RAG cache unbounded growth (memory leak)."""
+
+    def setup_method(self):
+        from lab_manager.services.rag import _CACHE
+
+        _CACHE.clear()
+
+    def test_evict_removes_stale_entries(self):
+        """Expired entries should be purged even if never re-requested."""
+        import time
+
+        from lab_manager.services.rag import _CACHE, _CACHE_TTL_S, _evict_cache
+
+        # Insert a stale entry
+        _CACHE["old_key"] = (time.time() - _CACHE_TTL_S - 1, {"answer": "stale"})
+
+        _evict_cache()
+        assert "old_key" not in _CACHE
+
+    def test_evict_enforces_max_size(self):
+        """Cache should cap at _CACHE_MAX_SIZE entries, evicting oldest."""
+        import time
+
+        from lab_manager.services.rag import _CACHE, _CACHE_MAX_SIZE, _evict_cache
+
+        original_max = _CACHE_MAX_SIZE
+        # Temporarily lower the max to 3 for testing
+        import lab_manager.services.rag as rag_mod
+
+        rag_mod._CACHE_MAX_SIZE = 3
+        try:
+            for i in range(5):
+                _CACHE[f"key_{i}"] = (time.time(), {"answer": f"a_{i}"})
+            _evict_cache()
+            assert len(_CACHE) <= 3
+            # Oldest entries should have been evicted
+            assert "key_0" not in _CACHE
+            assert "key_1" not in _CACHE
+        finally:
+            rag_mod._CACHE_MAX_SIZE = original_max
+            _CACHE.clear()


### PR DESCRIPTION
## Summary
- The `_CACHE` dict in `rag.py` grew without bound — stale entries were only evicted on cache hit (when the same question was asked again)
- Expired entries that were never re-requested accumulated indefinitely (memory leak)
- Each unique question cached up to 50 rows of SQL results plus metadata
- Fix: add `_evict_cache()` that removes stale entries (past TTL) and enforces `_CACHE_MAX_SIZE` (500 entries, evicting oldest)
- Called before each cache write to keep the cache bounded

## Test plan
- [x] 15/15 RAG service tests pass including 2 new `TestCacheEviction` tests
- [x] `test_evict_removes_stale_entries` — expired entries are purged
- [x] `test_evict_enforces_max_size` — oldest entries evicted when over limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)