### PR TITLE
feat(knowledge): lab knowledge base for SOPs and protocols

### DIFF
--- a/alembic/versions/c3d4e5f6a7b8_add_knowledge_entries_table.py
+++ b/alembic/versions/c3d4e5f6a7b8_add_knowledge_entries_table.py
@@ -1,0 +1,75 @@
+"""add knowledge_entries table
+
+Revision ID: c3d4e5f6a7b8
+Revises: 0c2125df7c3a
+Create Date: 2026-03-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, Sequence[str]] = "0c2125df7c3a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "knowledge_entries",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column(
+            "title", sqlmodel.sql.sqltypes.AutoString(length=500), nullable=False
+        ),
+        sa.Column(
+            "category",
+            sqlmodel.sql.sqltypes.AutoString(length=50),
+            nullable=False,
+            server_default="general",
+        ),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("tags", sa.JSON(), nullable=True),
+        sa.Column(
+            "source_type",
+            sqlmodel.sql.sqltypes.AutoString(length=100),
+            nullable=True,
+        ),
+        sa.Column(
+            "source_url",
+            sqlmodel.sql.sqltypes.AutoString(length=2000),
+            nullable=True,
+        ),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False
+        ),
+        sa.Column(
+            "created_by", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=True
+        ),
+        sa.CheckConstraint(
+            "category IN ('sop','safety','equipment_manual','protocol','troubleshooting','general')",
+            name="ck_knowledge_entries_category",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_knowledge_entries_title", "knowledge_entries", ["title"])
+    op.create_index("ix_knowledge_entries_category", "knowledge_entries", ["category"])
+    op.create_index(
+        "ix_knowledge_entries_is_deleted", "knowledge_entries", ["is_deleted"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_knowledge_entries_is_deleted")
+    op.drop_index("ix_knowledge_entries_category")
+    op.drop_index("ix_knowledge_entries_title")
+    op.drop_table("knowledge_entries")

--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -784,6 +784,7 @@ def create_app() -> FastAPI:
         export,
         import_routes,
         inventory,
+        knowledge,
         notifications,
         order_requests,
         orders,
@@ -845,6 +846,9 @@ def create_app() -> FastAPI:
     )
     api_router.include_router(
         devices.router, prefix="/api/v1/devices", tags=["devices"]
+    )
+    api_router.include_router(
+        knowledge.router, prefix="/api/v1/knowledge", tags=["knowledge"]
     )
 
     from lab_manager.api.routes import team

--- a/src/lab_manager/api/routes/knowledge.py
+++ b/src/lab_manager/api/routes/knowledge.py
@@ -1,0 +1,158 @@
+"""Knowledge base CRUD and search endpoints."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import or_, select
+from sqlalchemy.orm import Session
+
+from lab_manager.api.auth import require_permission
+from lab_manager.api.deps import get_db, get_or_404
+from lab_manager.api.pagination import apply_sort, ilike_col, paginate
+from lab_manager.models.knowledge import KnowledgeCategory
+
+router = APIRouter()
+
+_VALID_CATEGORIES = {c.value for c in KnowledgeCategory}
+
+_SORTABLE = {
+    "id",
+    "created_at",
+    "updated_at",
+    "title",
+    "category",
+}
+
+
+class KnowledgeCreate(BaseModel):
+    title: str = Field(max_length=500)
+    category: str = Field(default="general", max_length=50)
+    content: str
+    tags: list[str] = Field(default_factory=list)
+    source_type: Optional[str] = Field(default=None, max_length=100)
+    source_url: Optional[str] = Field(default=None, max_length=2000)
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        if v not in _VALID_CATEGORIES:
+            raise ValueError(f"category must be one of {sorted(_VALID_CATEGORIES)}")
+        return v
+
+
+class KnowledgeUpdate(BaseModel):
+    title: Optional[str] = Field(default=None, max_length=500)
+    category: Optional[str] = Field(default=None, max_length=50)
+    content: Optional[str] = None
+    tags: Optional[list[str]] = None
+    source_type: Optional[str] = Field(default=None, max_length=100)
+    source_url: Optional[str] = Field(default=None, max_length=2000)
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str | None) -> str | None:
+        if v is not None and v not in _VALID_CATEGORIES:
+            raise ValueError(f"category must be one of {sorted(_VALID_CATEGORIES)}")
+        return v
+
+
+@router.get("/")
+def list_knowledge(
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    category: Optional[str] = Query(None),
+    search: Optional[str] = Query(None),
+    sort_by: str = Query("id"),
+    sort_dir: str = Query("asc", pattern="^(asc|desc)$"),
+    db: Session = Depends(get_db),
+):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    q = select(KnowledgeEntry).where(KnowledgeEntry.is_deleted.is_(False))
+    if category:
+        q = q.where(KnowledgeEntry.category == category)
+    if search:
+        q = q.where(
+            ilike_col(KnowledgeEntry.title, search)
+            | ilike_col(KnowledgeEntry.content, search)
+        )
+    q = apply_sort(q, KnowledgeEntry, sort_by, sort_dir, _SORTABLE)
+    return paginate(q, db, page, page_size)
+
+
+@router.post(
+    "/",
+    status_code=201,
+    dependencies=[Depends(require_permission("upload_documents"))],
+)
+def create_knowledge(body: KnowledgeCreate, db: Session = Depends(get_db)):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    entry = KnowledgeEntry(**body.model_dump())
+    db.add(entry)
+    db.flush()
+    db.refresh(entry)
+    return entry
+
+
+@router.get("/search")
+def search_knowledge(
+    q: str = Query(..., min_length=1),
+    category: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=200),
+    db: Session = Depends(get_db),
+):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    stmt = select(KnowledgeEntry).where(
+        KnowledgeEntry.is_deleted.is_(False),
+        or_(
+            ilike_col(KnowledgeEntry.title, q),
+            ilike_col(KnowledgeEntry.content, q),
+        ),
+    )
+    if category:
+        stmt = stmt.where(KnowledgeEntry.category == category)
+    return paginate(stmt, db, page, page_size)
+
+
+@router.get("/{entry_id}")
+def get_knowledge(entry_id: int, db: Session = Depends(get_db)):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    return get_or_404(db, KnowledgeEntry, entry_id, "KnowledgeEntry")
+
+
+@router.patch(
+    "/{entry_id}",
+    dependencies=[Depends(require_permission("upload_documents"))],
+)
+def update_knowledge(
+    entry_id: int, body: KnowledgeUpdate, db: Session = Depends(get_db)
+):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    entry = get_or_404(db, KnowledgeEntry, entry_id, "KnowledgeEntry")
+    for key, value in body.model_dump(exclude_unset=True).items():
+        setattr(entry, key, value)
+    db.flush()
+    db.refresh(entry)
+    return entry
+
+
+@router.delete(
+    "/{entry_id}",
+    status_code=204,
+    dependencies=[Depends(require_permission("delete_records"))],
+)
+def delete_knowledge(entry_id: int, db: Session = Depends(get_db)):
+    from lab_manager.models.knowledge import KnowledgeEntry
+
+    entry = get_or_404(db, KnowledgeEntry, entry_id, "KnowledgeEntry")
+    entry.is_deleted = True
+    db.flush()
+    return None

--- a/src/lab_manager/models/__init__.py
+++ b/src/lab_manager/models/__init__.py
@@ -23,6 +23,7 @@ from lab_manager.models.import_job import (
     ImportStatus,
 )
 from lab_manager.models.device import Device, DeviceStatus
+from lab_manager.models.knowledge import KnowledgeEntry, KnowledgeCategory
 
 __all__ = [
     "AuditMixin",
@@ -59,4 +60,6 @@ __all__ = [
     "ImportStatus",
     "Device",
     "DeviceStatus",
+    "KnowledgeEntry",
+    "KnowledgeCategory",
 ]

--- a/src/lab_manager/models/knowledge.py
+++ b/src/lab_manager/models/knowledge.py
@@ -1,0 +1,40 @@
+"""Knowledge base model for SOPs, protocols, safety data, and equipment manuals."""
+
+from __future__ import annotations
+
+import enum
+from typing import Optional
+
+import sqlalchemy as sa
+from sqlalchemy import Column, Text
+from sqlmodel import Field
+
+from lab_manager.models.base import AuditMixin
+
+
+class KnowledgeCategory(str, enum.Enum):
+    sop = "sop"
+    safety = "safety"
+    equipment_manual = "equipment_manual"
+    protocol = "protocol"
+    troubleshooting = "troubleshooting"
+    general = "general"
+
+
+class KnowledgeEntry(AuditMixin, table=True):
+    __tablename__ = "knowledge_entries"
+    __table_args__ = (
+        sa.CheckConstraint(
+            "category IN ('sop','safety','equipment_manual','protocol','troubleshooting','general')",
+            name="ck_knowledge_entries_category",
+        ),
+    )
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str = Field(max_length=500, index=True)
+    category: str = Field(default="general", max_length=50, index=True)
+    content: str = Field(sa_column=Column(Text))
+    tags: list = Field(default_factory=list, sa_column=Column(sa.JSON))
+    source_type: Optional[str] = Field(default=None, max_length=100)
+    source_url: Optional[str] = Field(default=None, max_length=2000)
+    is_deleted: bool = Field(default=False, index=True)

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -1,0 +1,276 @@
+"""Knowledge base API endpoint tests."""
+
+from __future__ import annotations
+
+
+# --- CRUD ---
+
+
+def test_create_knowledge_entry(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Lab Safety SOP",
+            "category": "sop",
+            "content": "Always wear gloves and goggles in the lab.",
+            "tags": ["safety", "PPE"],
+        },
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["title"] == "Lab Safety SOP"
+    assert data["category"] == "sop"
+    assert data["tags"] == ["safety", "PPE"]
+    assert data["id"] is not None
+    assert data["is_deleted"] is False
+
+
+def test_create_knowledge_entry_default_category(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "General Note",
+            "content": "Some general information.",
+        },
+    )
+    assert r.status_code == 201
+    assert r.json()["category"] == "general"
+
+
+def test_create_knowledge_entry_invalid_category(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Bad",
+            "category": "invalid_cat",
+            "content": "test",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_get_knowledge_entry(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Chemical Spill Protocol",
+            "category": "safety",
+            "content": "Evacuate and call EHS.",
+        },
+    )
+    eid = r.json()["id"]
+    r = client.get(f"/api/v1/knowledge/{eid}")
+    assert r.status_code == 200
+    assert r.json()["title"] == "Chemical Spill Protocol"
+
+
+def test_get_knowledge_entry_404(client):
+    r = client.get("/api/v1/knowledge/99999")
+    assert r.status_code == 404
+
+
+def test_update_knowledge_entry(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Old Title", "content": "old content"},
+    )
+    eid = r.json()["id"]
+    r = client.patch(
+        f"/api/v1/knowledge/{eid}",
+        json={"title": "New Title", "content": "updated content"},
+    )
+    assert r.status_code == 200
+    assert r.json()["title"] == "New Title"
+    assert r.json()["content"] == "updated content"
+
+
+def test_update_knowledge_entry_partial(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Original", "content": "keep me"},
+    )
+    eid = r.json()["id"]
+    r = client.patch(f"/api/v1/knowledge/{eid}", json={"tags": ["updated"]})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["title"] == "Original"
+    assert data["content"] == "keep me"
+    assert data["tags"] == ["updated"]
+
+
+def test_soft_delete_knowledge_entry(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Delete Me", "content": "bye"},
+    )
+    eid = r.json()["id"]
+    r = client.delete(f"/api/v1/knowledge/{eid}")
+    assert r.status_code == 204
+
+
+def test_deleted_excluded_from_list(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Keep", "content": "stay"},
+    )
+    r2 = client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Gone", "content": "bye"},
+    )
+    client.delete(f"/api/v1/knowledge/{r2.json()['id']}")
+    r = client.get("/api/v1/knowledge/")
+    titles = [e["title"] for e in r.json()["items"]]
+    assert "Keep" in titles
+    assert "Gone" not in titles
+
+
+# --- Filtering ---
+
+
+def test_filter_by_category(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={"title": "SOP 1", "category": "sop", "content": "a"},
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Protocol 1", "category": "protocol", "content": "b"},
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={"title": "SOP 2", "category": "sop", "content": "c"},
+    )
+    r = client.get("/api/v1/knowledge/?category=sop")
+    assert len(r.json()["items"]) == 2
+
+
+# --- Search ---
+
+
+def test_search_in_list(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Centrifuge Manual",
+            "content": "Operating instructions for centrifuge.",
+        },
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={"title": "Microscope Guide", "content": "How to use the microscope."},
+    )
+    r = client.get("/api/v1/knowledge/?search=centrifuge")
+    items = r.json()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "Centrifuge Manual"
+
+
+def test_dedicated_search_endpoint(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "PCR Protocol",
+            "category": "protocol",
+            "content": "Step by step PCR amplification.",
+        },
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Western Blot",
+            "category": "protocol",
+            "content": "Protein detection protocol.",
+        },
+    )
+    r = client.get("/api/v1/knowledge/search?q=PCR")
+    assert r.status_code == 200
+    items = r.json()["items"]
+    assert len(items) == 1
+    assert items[0]["title"] == "PCR Protocol"
+
+
+def test_search_with_category_filter(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Safety Protocol A",
+            "category": "safety",
+            "content": "Fire extinguisher locations.",
+        },
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Safety Protocol B",
+            "category": "safety",
+            "content": "Emergency contacts.",
+        },
+    )
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "SOP A",
+            "category": "sop",
+            "content": "Safety procedures for chemicals.",
+        },
+    )
+    r = client.get("/api/v1/knowledge/search?q=Safety&category=safety")
+    items = r.json()["items"]
+    assert len(items) == 2
+    assert all(e["category"] == "safety" for e in items)
+
+
+def test_search_no_results(client):
+    r = client.get("/api/v1/knowledge/search?q=nonexistent_xyz")
+    assert r.status_code == 200
+    assert r.json()["total"] == 0
+    assert r.json()["items"] == []
+
+
+def test_search_content_match(client):
+    client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "General Info",
+            "content": "This document describes autoclave sterilization procedures.",
+        },
+    )
+    r = client.get("/api/v1/knowledge/search?q=autoclave")
+    assert len(r.json()["items"]) == 1
+
+
+# --- Pagination ---
+
+
+def test_list_pagination(client):
+    for i in range(5):
+        client.post(
+            "/api/v1/knowledge/",
+            json={"title": f"Entry {i}", "content": f"Content {i}"},
+        )
+    r = client.get("/api/v1/knowledge/?page=1&page_size=2")
+    data = r.json()
+    assert data["page"] == 1
+    assert data["page_size"] == 2
+    assert len(data["items"]) == 2
+    assert data["total"] == 5
+    assert data["pages"] == 3
+
+
+# --- Source fields ---
+
+
+def test_source_fields(client):
+    r = client.post(
+        "/api/v1/knowledge/",
+        json={
+            "title": "Vendor Manual",
+            "content": "Read the manual.",
+            "source_type": "url",
+            "source_url": "https://example.com/manual.pdf",
+        },
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["source_type"] == "url"
+    assert data["source_url"] == "https://example.com/manual.pdf"


### PR DESCRIPTION
## Summary
- Add `KnowledgeEntry` model with title, category (sop/safety/equipment_manual/protocol/troubleshooting/general), content, tags, source tracking, and soft delete
- Add 6 API endpoints: CRUD, list with category filter + search, and dedicated `/search` endpoint
- Add Alembic migration for `knowledge_entries` table
- 17 tests covering CRUD, category filtering, full-text search, pagination, and soft delete

## Test plan
- [x] `uv run pytest tests/test_knowledge.py -x -q --tb=short` — 17/17 passed
- [x] `uv run ruff check` — all clean
- [ ] CI pipeline passes (lint, typecheck, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)