### PR TITLE
feat(reports): AI weekly summary report service

### DIFF
--- a/src/lab_manager/api/app.py
+++ b/src/lab_manager/api/app.py
@@ -790,6 +790,7 @@ def create_app() -> FastAPI:
         order_requests,
         orders,
         products,
+        reports,
         safety,
         search,
         telemetry,
@@ -825,6 +826,9 @@ def create_app() -> FastAPI:
     api_router.include_router(ask.router, prefix="/api/v1/ask", tags=["ask"])
     api_router.include_router(
         analytics.router, prefix="/api/v1/analytics", tags=["analytics"]
+    )
+    api_router.include_router(
+        reports.router, prefix="/api/v1/reports", tags=["reports"]
     )
     api_router.include_router(export.router, prefix="/api/v1/export", tags=["export"])
     api_router.include_router(

--- a/src/lab_manager/api/routes/reports.py
+++ b/src/lab_manager/api/routes/reports.py
@@ -1,0 +1,46 @@
+"""Weekly report API endpoints."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
+from lab_manager.api.auth import require_permission
+from lab_manager.api.deps import get_db
+from lab_manager.services import weekly_report as svc
+
+router = APIRouter(dependencies=[Depends(require_permission("view_analytics"))])
+
+
+@router.get("/weekly")
+def get_weekly_report(
+    week_start: Optional[date] = Query(
+        None, description="Start of the week (Monday). Defaults to current week."
+    ),
+    db: Session = Depends(get_db),
+):
+    """Generate and return a weekly summary report."""
+    return svc.generate_weekly_report(db, week_start=week_start)
+
+
+@router.get("/weekly/pdf")
+def get_weekly_report_pdf(
+    week_start: Optional[date] = Query(
+        None, description="Start of the week (Monday). Defaults to current week."
+    ),
+    db: Session = Depends(get_db),
+):
+    """Return weekly report as downloadable JSON (PDF placeholder).
+
+    For now returns JSON with a Content-Disposition header for download.
+    Full PDF generation via reportlab can be added in a future iteration.
+    """
+    report = svc.generate_weekly_report(db, week_start=week_start)
+    response = JSONResponse(content=report)
+    filename = f"weekly-report-{report['report_period']['week_start']}.json"
+    response.headers["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return response

--- a/src/lab_manager/services/weekly_report.py
+++ b/src/lab_manager/services/weekly_report.py
@@ -1,0 +1,370 @@
+"""Weekly report service — aggregate queries for the past 7 days."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from lab_manager.models.alert import Alert
+from lab_manager.models.consumption import ConsumptionLog
+from lab_manager.models.document import Document, DocumentStatus
+from lab_manager.models.equipment import Equipment
+from lab_manager.models.inventory import InventoryItem
+from lab_manager.models.order import Order, OrderItem
+from lab_manager.models.product import Product
+from lab_manager.models.vendor import Vendor
+from lab_manager.services.serialization import serialize_value as _iso
+
+
+def _money(val) -> float:
+    """Round a numeric value to 2 decimal places, treating None as 0."""
+    if val is None:
+        return 0.0
+    return round(float(val), 2)
+
+
+def _default_week_start() -> date:
+    """Return the most recent Monday as the default week start."""
+    today = datetime.now(timezone.utc).date()
+    return today - timedelta(days=today.weekday())
+
+
+# ---------------------------------------------------------------------------
+# 1. New orders received this week
+# ---------------------------------------------------------------------------
+
+
+def _new_orders(db: Session, week_start: date, week_end: date) -> dict:
+    rows = db.execute(
+        select(
+            Order.id,
+            Order.po_number,
+            Vendor.name.label("vendor_name"),
+            Order.order_date,
+            Order.status,
+            func.coalesce(func.sum(OrderItem.quantity), 0).label("total_quantity"),
+            func.coalesce(func.sum(OrderItem.unit_price * OrderItem.quantity), 0).label(
+                "total_value"
+            ),
+        )
+        .outerjoin(Vendor, Order.vendor_id == Vendor.id)
+        .outerjoin(OrderItem, OrderItem.order_id == Order.id)
+        .where(
+            Order.created_at
+            >= datetime(
+                week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+            )
+        )
+        .where(
+            Order.created_at
+            < datetime(week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc)
+        )
+        .where(Order.status != "deleted")
+        .group_by(
+            Order.id, Order.po_number, Vendor.name, Order.order_date, Order.status
+        )
+        .order_by(Order.created_at.desc())
+    ).all()
+
+    total_value = sum(_money(r.total_value) for r in rows)
+    return {
+        "count": len(rows),
+        "total_value": total_value,
+        "orders": [
+            {
+                "id": r.id,
+                "po_number": r.po_number,
+                "vendor_name": r.vendor_name,
+                "order_date": _iso(r.order_date),
+                "status": r.status,
+                "total_value": _money(r.total_value),
+            }
+            for r in rows
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 2. Inventory consumed (top 10 products)
+# ---------------------------------------------------------------------------
+
+
+def _inventory_consumed(db: Session, week_start: date, week_end: date) -> dict:
+    rows = db.execute(
+        select(
+            Product.name.label("product_name"),
+            Product.catalog_number,
+            func.coalesce(func.sum(ConsumptionLog.quantity_used), 0).label(
+                "total_consumed"
+            ),
+            InventoryItem.unit.label("unit"),
+        )
+        .join(InventoryItem, ConsumptionLog.inventory_id == InventoryItem.id)
+        .join(Product, ConsumptionLog.product_id == Product.id)
+        .where(ConsumptionLog.action == "consume")
+        .where(
+            ConsumptionLog.created_at
+            >= datetime(
+                week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+            )
+        )
+        .where(
+            ConsumptionLog.created_at
+            < datetime(week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc)
+        )
+        .group_by(Product.name, Product.catalog_number, InventoryItem.unit)
+        .order_by(func.sum(ConsumptionLog.quantity_used).desc())
+        .limit(10)
+    ).all()
+
+    total_consumed = sum(float(r.total_consumed) for r in rows)
+    return {
+        "total_consumed": total_consumed,
+        "top_products": [
+            {
+                "product_name": r.product_name,
+                "catalog_number": r.catalog_number,
+                "quantity_consumed": float(r.total_consumed),
+                "unit": r.unit,
+            }
+            for r in rows
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 3. Documents processed (approved/rejected/pending)
+# ---------------------------------------------------------------------------
+
+
+def _documents_processed(db: Session, week_start: date, week_end: date) -> dict:
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+    )
+    week_end_dt = datetime(
+        week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc
+    )
+
+    total = (
+        db.execute(
+            select(func.count(Document.id)).where(
+                Document.created_at >= week_start_dt,
+                Document.created_at < week_end_dt,
+            )
+        ).scalar()
+        or 0
+    )
+
+    by_status_rows = db.execute(
+        select(Document.status, func.count(Document.id))
+        .where(
+            Document.created_at >= week_start_dt,
+            Document.created_at < week_end_dt,
+        )
+        .group_by(Document.status)
+    ).all()
+
+    by_status = {row[0]: int(row[1]) for row in by_status_rows}
+
+    return {
+        "total": total,
+        "approved": by_status.get(DocumentStatus.approved, 0),
+        "rejected": by_status.get(DocumentStatus.rejected, 0),
+        "pending": by_status.get(DocumentStatus.pending, 0)
+        + by_status.get(DocumentStatus.processing, 0)
+        + by_status.get(DocumentStatus.needs_review, 0),
+        "by_status": by_status,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 4. Spending by vendor
+# ---------------------------------------------------------------------------
+
+
+def _spending_by_vendor(db: Session, week_start: date, week_end: date) -> dict:
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+    )
+    week_end_dt = datetime(
+        week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc
+    )
+
+    rows = db.execute(
+        select(
+            Vendor.name.label("vendor_name"),
+            func.count(func.distinct(Order.id)).label("order_count"),
+            func.coalesce(func.sum(OrderItem.unit_price * OrderItem.quantity), 0).label(
+                "total_spend"
+            ),
+        )
+        .join(Order, Order.vendor_id == Vendor.id)
+        .join(OrderItem, OrderItem.order_id == Order.id)
+        .where(Order.created_at >= week_start_dt)
+        .where(Order.created_at < week_end_dt)
+        .where(Order.status != "deleted")
+        .group_by(Vendor.name)
+        .order_by(func.sum(OrderItem.unit_price * OrderItem.quantity).desc())
+    ).all()
+
+    total_spend = sum(_money(r.total_spend) for r in rows)
+    return {
+        "total_spend": total_spend,
+        "vendors": [
+            {
+                "vendor_name": r.vendor_name,
+                "order_count": int(r.order_count),
+                "total_spend": _money(r.total_spend),
+            }
+            for r in rows
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 5. Alerts triggered
+# ---------------------------------------------------------------------------
+
+
+def _alerts_triggered(db: Session, week_start: date, week_end: date) -> dict:
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+    )
+    week_end_dt = datetime(
+        week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc
+    )
+
+    total = (
+        db.execute(
+            select(func.count(Alert.id)).where(
+                Alert.created_at >= week_start_dt,
+                Alert.created_at < week_end_dt,
+            )
+        ).scalar()
+        or 0
+    )
+
+    by_severity_rows = db.execute(
+        select(Alert.severity, func.count(Alert.id))
+        .where(
+            Alert.created_at >= week_start_dt,
+            Alert.created_at < week_end_dt,
+        )
+        .group_by(Alert.severity)
+    ).all()
+
+    by_severity = {row[0]: int(row[1]) for row in by_severity_rows}
+
+    by_type_rows = db.execute(
+        select(Alert.alert_type, func.count(Alert.id))
+        .where(
+            Alert.created_at >= week_start_dt,
+            Alert.created_at < week_end_dt,
+        )
+        .group_by(Alert.alert_type)
+    ).all()
+
+    by_type = {row[0]: int(row[1]) for row in by_type_rows}
+
+    unacknowledged = (
+        db.execute(
+            select(func.count(Alert.id)).where(
+                Alert.created_at >= week_start_dt,
+                Alert.created_at < week_end_dt,
+                Alert.is_acknowledged.is_(False),
+            )
+        ).scalar()
+        or 0
+    )
+
+    return {
+        "total": total,
+        "by_severity": by_severity,
+        "by_type": by_type,
+        "unacknowledged": unacknowledged,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 6. Equipment status changes
+# ---------------------------------------------------------------------------
+
+
+def _equipment_status_changes(db: Session, week_start: date, week_end: date) -> dict:
+    week_start_dt = datetime(
+        week_start.year, week_start.month, week_start.day, tzinfo=timezone.utc
+    )
+    week_end_dt = datetime(
+        week_end.year, week_end.month, week_end.day, tzinfo=timezone.utc
+    )
+
+    # Equipment updated this week (status likely changed)
+    updated_rows = db.scalars(
+        select(Equipment)
+        .where(
+            Equipment.updated_at >= week_start_dt,
+            Equipment.updated_at < week_end_dt,
+        )
+        .order_by(Equipment.updated_at.desc())
+    ).all()
+
+    by_status_rows = db.execute(
+        select(Equipment.status, func.count(Equipment.id))
+        .where(
+            Equipment.updated_at >= week_start_dt,
+            Equipment.updated_at < week_end_dt,
+        )
+        .group_by(Equipment.status)
+    ).all()
+
+    by_status = {row[0]: int(row[1]) for row in by_status_rows}
+
+    changes = [
+        {
+            "id": eq.id,
+            "name": eq.name,
+            "status": eq.status,
+            "category": eq.category,
+            "room": eq.room,
+            "updated_at": _iso(eq.updated_at),
+        }
+        for eq in updated_rows
+    ]
+
+    return {
+        "total_changed": len(changes),
+        "by_status": by_status,
+        "changes": changes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def generate_weekly_report(db: Session, week_start: Optional[date] = None) -> dict:
+    """Generate a weekly summary report for the 7-day window starting at *week_start*.
+
+    If *week_start* is None, defaults to the most recent Monday.
+    """
+    if week_start is None:
+        week_start = _default_week_start()
+    week_end = week_start + timedelta(days=7)
+
+    return {
+        "report_period": {
+            "week_start": _iso(week_start),
+            "week_end": _iso(week_end),
+        },
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "new_orders": _new_orders(db, week_start, week_end),
+        "inventory_consumed": _inventory_consumed(db, week_start, week_end),
+        "documents_processed": _documents_processed(db, week_start, week_end),
+        "spending_by_vendor": _spending_by_vendor(db, week_start, week_end),
+        "alerts_triggered": _alerts_triggered(db, week_start, week_end),
+        "equipment_status_changes": _equipment_status_changes(db, week_start, week_end),
+    }

--- a/tests/test_weekly_report.py
+++ b/tests/test_weekly_report.py
@@ -1,0 +1,479 @@
+"""Test weekly report service and API endpoints."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from lab_manager.models.alert import Alert
+from lab_manager.models.consumption import ConsumptionLog
+from lab_manager.models.document import Document
+from lab_manager.models.equipment import Equipment
+from lab_manager.models.inventory import InventoryItem
+from lab_manager.models.order import Order, OrderItem
+from lab_manager.models.product import Product
+from lab_manager.models.vendor import Vendor
+from lab_manager.services.weekly_report import generate_weekly_report
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_WEEK_START = date(2026, 3, 23)  # a Monday
+_WEEK_END = date(2026, 3, 30)
+
+
+def _seed_vendor(db, name="Thermo Fisher"):
+    v = Vendor(name=name)
+    db.add(v)
+    db.flush()
+    return v
+
+
+def _seed_product(db, vendor_id, catalog="A123", name="Antibody X"):
+    p = Product(catalog_number=catalog, name=name, vendor_id=vendor_id)
+    db.add(p)
+    db.flush()
+    return p
+
+
+def _seed_order(db, vendor_id, order_date=None, created_at=None, status="pending"):
+    kwargs = {"vendor_id": vendor_id, "status": status}
+    if order_date:
+        kwargs["order_date"] = order_date
+    o = Order(**kwargs)
+    if created_at:
+        o.created_at = created_at
+    db.add(o)
+    db.flush()
+    return o
+
+
+def _seed_order_item(db, order_id, qty=1, price=10.0, product_id=None):
+    kwargs = {
+        "order_id": order_id,
+        "catalog_number": "A123",
+        "description": "Test item",
+        "quantity": qty,
+        "unit_price": price,
+    }
+    if product_id:
+        kwargs["product_id"] = product_id
+    oi = OrderItem(**kwargs)
+    db.add(oi)
+    db.flush()
+    return oi
+
+
+def _seed_inventory(db, product_id, qty=10.0, unit="mL"):
+    inv = InventoryItem(
+        product_id=product_id,
+        quantity_on_hand=qty,
+        unit=unit,
+        status="available",
+    )
+    db.add(inv)
+    db.flush()
+    return inv
+
+
+def _seed_consumption(db, inventory_id, product_id, qty, created_at=None):
+    c = ConsumptionLog(
+        inventory_id=inventory_id,
+        product_id=product_id,
+        quantity_used=qty,
+        quantity_remaining=0,
+        consumed_by="Alice",
+        action="consume",
+    )
+    if created_at:
+        c.created_at = created_at
+    db.add(c)
+    db.flush()
+    return c
+
+
+def _seed_document(db, status="approved", created_at=None):
+    now = datetime.now(timezone.utc)
+    d = Document(
+        file_path=f"uploads/doc_{now.timestamp()}.jpg",
+        file_name=f"doc_{now.timestamp()}.jpg",
+        status=status,
+    )
+    if created_at:
+        d.created_at = created_at
+    db.add(d)
+    db.flush()
+    return d
+
+
+def _seed_alert(db, severity="warning", alert_type="low_stock", created_at=None):
+    a = Alert(
+        alert_type=alert_type,
+        severity=severity,
+        message="Test alert",
+        entity_type="inventory",
+        entity_id=1,
+    )
+    if created_at:
+        a.created_at = created_at
+    db.add(a)
+    db.flush()
+    return a
+
+
+def _seed_equipment(db, name="Centrifuge", status="active", updated_at=None):
+    e = Equipment(name=name, status=status)
+    if updated_at:
+        e.updated_at = updated_at
+    db.add(e)
+    db.flush()
+    return e
+
+
+def _dt(d: date) -> datetime:
+    """Convert a date to a UTC datetime at noon."""
+    return datetime(d.year, d.month, d.day, 12, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Tests — service layer (empty database)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDatabase:
+    """Weekly report on empty database returns zeros."""
+
+    def test_empty_orders(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["new_orders"]["count"] == 0
+        assert report["new_orders"]["total_value"] == 0.0
+        assert report["new_orders"]["orders"] == []
+
+    def test_empty_consumption(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["inventory_consumed"]["total_consumed"] == 0.0
+        assert report["inventory_consumed"]["top_products"] == []
+
+    def test_empty_documents(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        docs = report["documents_processed"]
+        assert docs["total"] == 0
+        assert docs["approved"] == 0
+        assert docs["rejected"] == 0
+        assert docs["pending"] == 0
+
+    def test_empty_spending(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["spending_by_vendor"]["total_spend"] == 0.0
+        assert report["spending_by_vendor"]["vendors"] == []
+
+    def test_empty_alerts(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        alerts = report["alerts_triggered"]
+        assert alerts["total"] == 0
+        assert alerts["unacknowledged"] == 0
+
+    def test_empty_equipment(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        eq = report["equipment_status_changes"]
+        assert eq["total_changed"] == 0
+        assert eq["changes"] == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — service layer (with sample data)
+# ---------------------------------------------------------------------------
+
+
+class TestWithData:
+    """Weekly report with data in the reporting window."""
+
+    def test_new_orders_counted(self, db_session):
+        v = _seed_vendor(db_session)
+        p = _seed_product(db_session, v.id)
+        o1 = _seed_order(
+            db_session,
+            v.id,
+            created_at=_dt(_WEEK_START),
+            status="pending",
+        )
+        _seed_order_item(db_session, o1.id, qty=5, price=20.0, product_id=p.id)
+        o2 = _seed_order(
+            db_session,
+            v.id,
+            created_at=_dt(_WEEK_START + timedelta(days=2)),
+            status="received",
+        )
+        _seed_order_item(db_session, o2.id, qty=3, price=15.0, product_id=p.id)
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["new_orders"]["count"] == 2
+        # 5*20 + 3*15 = 145
+        assert report["new_orders"]["total_value"] == 145.0
+
+    def test_orders_outside_window_excluded(self, db_session):
+        v = _seed_vendor(db_session)
+        # Order before the week
+        o_before = _seed_order(
+            db_session,
+            v.id,
+            created_at=_dt(_WEEK_START - timedelta(days=1)),
+        )
+        _seed_order_item(db_session, o_before.id, qty=1, price=100.0)
+        # Order after the week
+        o_after = _seed_order(
+            db_session,
+            v.id,
+            created_at=_dt(_WEEK_END),
+        )
+        _seed_order_item(db_session, o_after.id, qty=1, price=200.0)
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["new_orders"]["count"] == 0
+        assert report["new_orders"]["total_value"] == 0.0
+
+    def test_deleted_orders_excluded(self, db_session):
+        v = _seed_vendor(db_session)
+        o = _seed_order(
+            db_session,
+            v.id,
+            created_at=_dt(_WEEK_START),
+            status="deleted",
+        )
+        _seed_order_item(db_session, o.id, qty=1, price=50.0)
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["new_orders"]["count"] == 0
+
+    def test_consumption_top_products(self, db_session):
+        v = _seed_vendor(db_session)
+        p1 = _seed_product(db_session, v.id, catalog="P1", name="Product A")
+        p2 = _seed_product(db_session, v.id, catalog="P2", name="Product B")
+        inv1 = _seed_inventory(db_session, p1.id, qty=100.0)
+        inv2 = _seed_inventory(db_session, p2.id, qty=200.0)
+        _seed_consumption(
+            db_session,
+            inv1.id,
+            p1.id,
+            30.0,
+            created_at=_dt(_WEEK_START + timedelta(days=1)),
+        )
+        _seed_consumption(
+            db_session,
+            inv1.id,
+            p1.id,
+            20.0,
+            created_at=_dt(_WEEK_START + timedelta(days=2)),
+        )
+        _seed_consumption(
+            db_session,
+            inv2.id,
+            p2.id,
+            10.0,
+            created_at=_dt(_WEEK_START + timedelta(days=3)),
+        )
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        consumed = report["inventory_consumed"]
+        assert consumed["total_consumed"] == 60.0
+        assert len(consumed["top_products"]) == 2
+        assert consumed["top_products"][0]["product_name"] == "Product A"
+        assert consumed["top_products"][0]["quantity_consumed"] == 50.0
+
+    def test_documents_by_status(self, db_session):
+        _seed_document(db_session, status="approved", created_at=_dt(_WEEK_START))
+        _seed_document(
+            db_session,
+            status="approved",
+            created_at=_dt(_WEEK_START + timedelta(days=1)),
+        )
+        _seed_document(
+            db_session,
+            status="rejected",
+            created_at=_dt(_WEEK_START + timedelta(days=2)),
+        )
+        _seed_document(
+            db_session,
+            status="pending",
+            created_at=_dt(_WEEK_START + timedelta(days=3)),
+        )
+        _seed_document(
+            db_session,
+            status="needs_review",
+            created_at=_dt(_WEEK_START + timedelta(days=4)),
+        )
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        docs = report["documents_processed"]
+        assert docs["total"] == 5
+        assert docs["approved"] == 2
+        assert docs["rejected"] == 1
+        # pending + needs_review = 2
+        assert docs["pending"] == 2
+
+    def test_spending_by_vendor(self, db_session):
+        v1 = _seed_vendor(db_session, "Vendor A")
+        v2 = _seed_vendor(db_session, "Vendor B")
+        o1 = _seed_order(db_session, v1.id, created_at=_dt(_WEEK_START))
+        _seed_order_item(db_session, o1.id, qty=10, price=5.0)
+        o2 = _seed_order(
+            db_session, v2.id, created_at=_dt(_WEEK_START + timedelta(days=1))
+        )
+        _seed_order_item(db_session, o2.id, qty=2, price=50.0)
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        spending = report["spending_by_vendor"]
+        assert spending["total_spend"] == 150.0
+        assert len(spending["vendors"]) == 2
+        # Vendor B should be first (higher spend: 2*50=100 > 10*5=50)
+        assert spending["vendors"][0]["vendor_name"] == "Vendor B"
+
+    def test_alerts_triggered(self, db_session):
+        _seed_alert(
+            db_session,
+            severity="critical",
+            alert_type="expired",
+            created_at=_dt(_WEEK_START),
+        )
+        _seed_alert(
+            db_session,
+            severity="warning",
+            alert_type="low_stock",
+            created_at=_dt(_WEEK_START + timedelta(days=2)),
+        )
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        alerts = report["alerts_triggered"]
+        assert alerts["total"] == 2
+        assert alerts["by_severity"]["critical"] == 1
+        assert alerts["by_severity"]["warning"] == 1
+        assert alerts["by_type"]["expired"] == 1
+        assert alerts["by_type"]["low_stock"] == 1
+        assert alerts["unacknowledged"] == 2
+
+    def test_alerts_acknowledged_excluded_from_unacknowledged(self, db_session):
+        a = _seed_alert(
+            db_session,
+            severity="info",
+            alert_type="pending_review",
+            created_at=_dt(_WEEK_START),
+        )
+        a.is_acknowledged = True
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        alerts = report["alerts_triggered"]
+        assert alerts["total"] == 1
+        assert alerts["unacknowledged"] == 0
+
+    def test_equipment_status_changes(self, db_session):
+        _seed_equipment(
+            db_session,
+            name="Centrifuge",
+            status="maintenance",
+            updated_at=_dt(_WEEK_START + timedelta(days=1)),
+        )
+        _seed_equipment(
+            db_session,
+            name="PCR Machine",
+            status="active",
+            updated_at=_dt(_WEEK_START + timedelta(days=3)),
+        )
+        db_session.commit()
+
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        eq = report["equipment_status_changes"]
+        assert eq["total_changed"] == 2
+        assert eq["by_status"]["maintenance"] == 1
+        assert eq["by_status"]["active"] == 1
+
+    def test_report_period_structure(self, db_session):
+        report = generate_weekly_report(db_session, week_start=_WEEK_START)
+        assert report["report_period"]["week_start"] == "2026-03-23"
+        assert report["report_period"]["week_end"] == "2026-03-30"
+        assert "generated_at" in report
+
+    def test_default_week_start(self, db_session):
+        report = generate_weekly_report(db_session)
+        start = date.fromisoformat(report["report_period"]["week_start"])
+        end = date.fromisoformat(report["report_period"]["week_end"])
+        assert (end - start).days == 7
+        # Should be a Monday
+        assert start.weekday() == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests — API endpoints
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklyReportAPI:
+    """Test the /api/v1/reports/weekly endpoint."""
+
+    def test_weekly_report_endpoint(self, client):
+        resp = client.get("/api/v1/reports/weekly")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "new_orders" in data
+        assert "inventory_consumed" in data
+        assert "documents_processed" in data
+        assert "spending_by_vendor" in data
+        assert "alerts_triggered" in data
+        assert "equipment_status_changes" in data
+        assert "report_period" in data
+
+    def test_weekly_report_with_date(self, client):
+        resp = client.get(
+            "/api/v1/reports/weekly",
+            params={"week_start": "2026-03-23"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["report_period"]["week_start"] == "2026-03-23"
+        assert data["report_period"]["week_end"] == "2026-03-30"
+
+    def test_weekly_report_pdf_endpoint(self, client):
+        resp = client.get(
+            "/api/v1/reports/weekly/pdf",
+            params={"week_start": "2026-03-23"},
+        )
+        assert resp.status_code == 200
+        assert "attachment" in resp.headers.get("content-disposition", "")
+        data = resp.json()
+        assert "new_orders" in data
+
+    def test_weekly_report_empty_database(self, client):
+        resp = client.get("/api/v1/reports/weekly")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["new_orders"]["count"] == 0
+        assert data["documents_processed"]["total"] == 0
+        assert data["alerts_triggered"]["total"] == 0
+
+    def test_weekly_report_with_data(self, client, db_session):
+        v = _seed_vendor(db_session, "BioRad")
+        p = _seed_product(db_session, v.id, catalog="B1", name="Buffer")
+        o = _seed_order(
+            db_session,
+            v.id,
+            order_date=date(2026, 3, 24),
+            created_at=_dt(_WEEK_START + timedelta(days=1)),
+            status="received",
+        )
+        _seed_order_item(db_session, o.id, qty=3, price=25.0, product_id=p.id)
+        db_session.commit()
+
+        resp = client.get(
+            "/api/v1/reports/weekly",
+            params={"week_start": "2026-03-23"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["new_orders"]["count"] == 1
+        assert data["new_orders"]["total_value"] == 75.0


### PR DESCRIPTION
## Summary

- Add `src/lab_manager/services/weekly_report.py` with `generate_weekly_report()` that queries all relevant tables for a 7-day window
- Add `src/lab_manager/api/routes/reports.py` with two endpoints:
  - `GET /api/v1/reports/weekly` — returns JSON weekly report
  - `GET /api/v1/reports/weekly/pdf` — returns downloadable JSON (PDF placeholder)
- Register the reports router in `app.py`
- Report sections: new orders, inventory consumed (top 10), documents processed (by status), spending by vendor, alerts triggered, equipment status changes

## Test plan

- [x] 22 tests in `tests/test_weekly_report.py`
- [x] Empty database returns zeros for all sections
- [x] Sample data returns correct counts and values
- [x] Date range filtering excludes records outside the week
- [x] API endpoints return 200 with correct structure
- [x] All tests pass: `uv run pytest tests/test_weekly_report.py -x -q --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)